### PR TITLE
feat(csp): implement Content Security Policy (CSP) module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { MaskingModule } from './common/masking/masking.module';
+import { CspModule } from './csp/csp.module';
 import { ValidationModule } from './validation/validation.module';
 import {
   MaskingInterceptor,
@@ -23,6 +24,7 @@ import { FileUploadModule } from './file-upload/file-upload.module';
     SecurityHeaderModule,
     ValidationModule,
     FileUploadModule,
+    CspModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/csp/csp.controller.ts
+++ b/backend/src/csp/csp.controller.ts
@@ -1,0 +1,76 @@
+import { Controller, Post, Get, Req, UseGuards, Query } from "@nestjs/common"
+import type { Request } from "express"
+import type { CspService } from "./csp.service"
+import { JwtAuthGuard } from "../../auth/guards/jwt-auth.guard"
+
+@Controller("security/csp")
+export class CspController {
+  constructor(private readonly cspService: CspService) {}
+
+  /**
+   * CSP violation reporting endpoint
+   */
+  @Post("report")
+  async reportViolation(report: any, @Req() req: Request) {
+    try {
+      this.cspService.logViolation(report, req)
+      return { success: true, message: "Violation report received" }
+    } catch (error) {
+      return { success: false, message: "Failed to process violation report" }
+    }
+  }
+
+  /**
+   * Get CSP violation reports (admin only)
+   */
+  @Get("violations")
+  @UseGuards(JwtAuthGuard)
+  async getViolations(@Query("limit") limit?: string) {
+    const limitNum = limit ? Number.parseInt(limit, 10) : 100
+    const reports = this.cspService.getViolationReports(limitNum)
+    return {
+      success: true,
+      data: reports,
+      count: reports.length,
+    }
+  }
+
+  /**
+   * Get CSP violation statistics (admin only)
+   */
+  @Get("violations/stats")
+  @UseGuards(JwtAuthGuard)
+  async getViolationStats() {
+    const stats = this.cspService.getViolationStats()
+    return {
+      success: true,
+      data: stats,
+    }
+  }
+
+  /**
+   * Clear CSP violation reports (admin only)
+   */
+  @Post("violations/clear")
+  @UseGuards(JwtAuthGuard)
+  async clearViolations() {
+    this.cspService.clearViolationReports()
+    return {
+      success: true,
+      message: "Violation reports cleared",
+    }
+  }
+
+  /**
+   * Get current CSP configuration (admin only)
+   */
+  @Get("config")
+  @UseGuards(JwtAuthGuard)
+  async getCspConfig(@Req() req: Request) {
+    const config = this.cspService.getCspConfig(req)
+    return {
+      success: true,
+      data: config,
+    }
+  }
+}

--- a/backend/src/csp/csp.middleware.ts
+++ b/backend/src/csp/csp.middleware.ts
@@ -1,0 +1,52 @@
+import { Injectable, type NestMiddleware, Logger } from "@nestjs/common"
+import type { Request, Response, NextFunction } from "express"
+import * as helmet from "helmet"
+import type { CspService } from "./csp.service"
+
+@Injectable()
+export class CspMiddleware implements NestMiddleware {
+  private readonly logger = new Logger(CspMiddleware.name)
+
+  constructor(private readonly cspService: CspService) {}
+
+  use(req: Request, res: Response, next: NextFunction) {
+    // Get CSP configuration based on environment and route
+    const cspConfig = this.cspService.getCspConfig(req)
+
+    // Apply Helmet with CSP configuration
+    const helmetMiddleware = helmet({
+      contentSecurityPolicy: {
+        directives: cspConfig.directives,
+        reportOnly: cspConfig.reportOnly,
+        useDefaults: false, // We'll define our own defaults
+      },
+      // Additional security headers
+      crossOriginEmbedderPolicy: false, // Disable if causing issues with third-party embeds
+      crossOriginResourcePolicy: { policy: "cross-origin" },
+      dnsPrefetchControl: { allow: false },
+      frameguard: { action: "deny" },
+      hidePoweredBy: true,
+      hsts: {
+        maxAge: 31536000, // 1 year
+        includeSubDomains: true,
+        preload: true,
+      },
+      ieNoOpen: true,
+      noSniff: true,
+      originAgentCluster: true,
+      permittedCrossDomainPolicies: false,
+      referrerPolicy: { policy: "no-referrer" },
+      xssFilter: true,
+    })
+
+    // Log CSP configuration in development
+    if (process.env.NODE_ENV === "development") {
+      this.logger.debug(`CSP applied for ${req.method} ${req.path}`, {
+        directives: cspConfig.directives,
+        reportOnly: cspConfig.reportOnly,
+      })
+    }
+
+    helmetMiddleware(req, res, next)
+  }
+}

--- a/backend/src/csp/csp.module.ts
+++ b/backend/src/csp/csp.module.ts
@@ -1,0 +1,17 @@
+import { Module, type MiddlewareConsumer, type NestModule } from "@nestjs/common"
+import { ConfigModule } from "@nestjs/config"
+import { CspMiddleware } from "./csp.middleware"
+import { CspService } from "./csp.service"
+import { CspController } from "./csp.controller"
+
+@Module({
+  imports: [ConfigModule],
+  providers: [CspService],
+  controllers: [CspController],
+  exports: [CspService],
+})
+export class CspModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CspMiddleware).forRoutes("*")
+  }
+}

--- a/backend/src/csp/csp.service.ts
+++ b/backend/src/csp/csp.service.ts
@@ -1,0 +1,369 @@
+import { Injectable, Logger } from "@nestjs/common"
+import type { ConfigService } from "@nestjs/config"
+import type { Request } from "express"
+
+export interface CspDirectives {
+  defaultSrc?: string[]
+  scriptSrc?: string[]
+  styleSrc?: string[]
+  imgSrc?: string[]
+  connectSrc?: string[]
+  fontSrc?: string[]
+  objectSrc?: string[]
+  mediaSrc?: string[]
+  frameSrc?: string[]
+  childSrc?: string[]
+  workerSrc?: string[]
+  manifestSrc?: string[]
+  prefetchSrc?: string[]
+  formAction?: string[]
+  frameAncestors?: string[]
+  baseUri?: string[]
+  upgradeInsecureRequests?: boolean
+  blockAllMixedContent?: boolean
+  requireTrustedTypesFor?: string[]
+  trustedTypes?: string[]
+  reportUri?: string[]
+  reportTo?: string
+}
+
+export interface CspConfig {
+  directives: CspDirectives
+  reportOnly: boolean
+}
+
+interface CspViolationReport {
+  timestamp: Date
+  userAgent: string
+  ip: string
+  violatedDirective: string
+  blockedUri: string
+  documentUri: string
+  originalPolicy: string
+  disposition: string
+  statusCode: number
+}
+
+@Injectable()
+export class CspService {
+  private readonly logger = new Logger(CspService.name)
+  private violationReports: CspViolationReport[] = []
+
+  constructor(private readonly configService: ConfigService) {}
+
+  /**
+   * Get CSP configuration based on environment and request context
+   */
+  getCspConfig(req: Request): CspConfig {
+    const environment = this.configService.get<string>("NODE_ENV", "development")
+    const isProduction = environment === "production"
+
+    // Base CSP configuration
+    const baseDirectives: CspDirectives = {
+      defaultSrc: ["'self'"],
+      scriptSrc: this.getScriptSrcDirectives(isProduction, req),
+      styleSrc: this.getStyleSrcDirectives(isProduction),
+      imgSrc: this.getImgSrcDirectives(),
+      connectSrc: this.getConnectSrcDirectives(isProduction),
+      fontSrc: this.getFontSrcDirectives(),
+      objectSrc: ["'none'"],
+      mediaSrc: ["'self'"],
+      frameSrc: this.getFrameSrcDirectives(),
+      childSrc: ["'self'"],
+      workerSrc: ["'self'"],
+      manifestSrc: ["'self'"],
+      formAction: ["'self'"],
+      frameAncestors: ["'none'"],
+      baseUri: ["'self'"],
+      upgradeInsecureRequests: isProduction,
+      blockAllMixedContent: isProduction,
+    }
+
+    // Add trusted types for modern browsers
+    if (isProduction) {
+      baseDirectives.requireTrustedTypesFor = ["'script'"]
+      baseDirectives.trustedTypes = ["default"]
+    }
+
+    // Add reporting
+    const reportUri = this.configService.get<string>("CSP_REPORT_URI")
+    if (reportUri) {
+      baseDirectives.reportUri = [reportUri]
+    }
+
+    // Route-specific CSP modifications
+    const routeSpecificDirectives = this.getRouteSpecificDirectives(req)
+    const mergedDirectives = this.mergeDirectives(baseDirectives, routeSpecificDirectives)
+
+    return {
+      directives: mergedDirectives,
+      reportOnly: this.configService.get<boolean>("CSP_REPORT_ONLY", !isProduction),
+    }
+  }
+
+  /**
+   * Get script source directives
+   */
+  private getScriptSrcDirectives(isProduction: boolean, req: Request): string[] {
+    const scriptSrc = ["'self'"]
+
+    if (!isProduction) {
+      // Allow inline scripts and eval in development
+      scriptSrc.push("'unsafe-inline'", "'unsafe-eval'")
+      // Allow localhost for development servers
+      scriptSrc.push("http://localhost:*", "ws://localhost:*")
+    } else {
+      // Use nonces or hashes in production
+      const nonce = this.generateNonce()
+      req.cspNonce = nonce // Store nonce in request for use in templates
+      scriptSrc.push(`'nonce-${nonce}'`)
+    }
+
+    // Add trusted CDNs
+    const trustedCdns = this.configService.get<string>("CSP_TRUSTED_SCRIPT_CDNS", "")
+    if (trustedCdns) {
+      scriptSrc.push(...trustedCdns.split(",").map((cdn) => cdn.trim()))
+    }
+
+    // Common trusted CDNs
+    scriptSrc.push(
+      "https://cdn.jsdelivr.net",
+      "https://unpkg.com",
+      "https://cdnjs.cloudflare.com",
+      "https://www.googletagmanager.com", // Google Analytics
+      "https://www.google-analytics.com",
+    )
+
+    return scriptSrc
+  }
+
+  /**
+   * Get style source directives
+   */
+  private getStyleSrcDirectives(isProduction: boolean): string[] {
+    const styleSrc = ["'self'"]
+
+    if (!isProduction) {
+      styleSrc.push("'unsafe-inline'")
+    } else {
+      // Allow inline styles with specific hashes or use nonces
+      styleSrc.push("'unsafe-inline'") // Consider using nonces or hashes instead
+    }
+
+    // Add trusted style CDNs
+    styleSrc.push(
+      "https://fonts.googleapis.com",
+      "https://cdn.jsdelivr.net",
+      "https://unpkg.com",
+      "https://cdnjs.cloudflare.com",
+    )
+
+    return styleSrc
+  }
+
+  /**
+   * Get image source directives
+   */
+  private getImgSrcDirectives(): string[] {
+    return [
+      "'self'",
+      "data:", // Allow data URLs for inline images
+      "blob:", // Allow blob URLs
+      "https:", // Allow all HTTPS images
+      "https://images.unsplash.com", // Common image CDN
+      "https://via.placeholder.com", // Placeholder service
+    ]
+  }
+
+  /**
+   * Get connect source directives
+   */
+  private getConnectSrcDirectives(isProduction: boolean): string[] {
+    const connectSrc = ["'self'"]
+
+    if (!isProduction) {
+      connectSrc.push("http://localhost:*", "ws://localhost:*", "wss://localhost:*")
+    }
+
+    // Add API endpoints
+    const apiEndpoints = this.configService.get<string>("CSP_API_ENDPOINTS", "")
+    if (apiEndpoints) {
+      connectSrc.push(...apiEndpoints.split(",").map((endpoint) => endpoint.trim()))
+    }
+
+    // Common services
+    connectSrc.push("https://api.github.com", "https://www.google-analytics.com", "https://analytics.google.com")
+
+    return connectSrc
+  }
+
+  /**
+   * Get font source directives
+   */
+  private getFontSrcDirectives(): string[] {
+    return [
+      "'self'",
+      "data:", // Allow data URLs for fonts
+      "https://fonts.gstatic.com",
+      "https://cdn.jsdelivr.net",
+      "https://cdnjs.cloudflare.com",
+    ]
+  }
+
+  /**
+   * Get frame source directives
+   */
+  private getFrameSrcDirectives(): string[] {
+    const frameSrc = ["'none'"] // Default to no frames
+
+    // Add trusted frame sources if needed
+    const trustedFrames = this.configService.get<string>("CSP_TRUSTED_FRAMES", "")
+    if (trustedFrames) {
+      return trustedFrames.split(",").map((frame) => frame.trim())
+    }
+
+    return frameSrc
+  }
+
+  /**
+   * Get route-specific CSP directives
+   */
+  private getRouteSpecificDirectives(req: Request): Partial<CspDirectives> {
+    const path = req.path
+
+    // Admin routes might need different CSP
+    if (path.startsWith("/admin")) {
+      return {
+        scriptSrc: ["'self'", "'unsafe-inline'"], // Admin might need inline scripts
+        styleSrc: ["'self'", "'unsafe-inline'"],
+      }
+    }
+
+    // API routes might not need script sources
+    if (path.startsWith("/api")) {
+      return {
+        scriptSrc: ["'none'"],
+        styleSrc: ["'none'"],
+        imgSrc: ["'none'"],
+      }
+    }
+
+    // OAuth callback routes might need specific frame sources
+    if (path.includes("/auth/") && path.includes("/callback")) {
+      return {
+        frameSrc: ["https://accounts.google.com", "https://www.facebook.com"],
+      }
+    }
+
+    return {}
+  }
+
+  /**
+   * Merge CSP directives
+   */
+  private mergeDirectives(base: CspDirectives, override: Partial<CspDirectives>): CspDirectives {
+    const merged = { ...base }
+
+    for (const [key, value] of Object.entries(override)) {
+      if (Array.isArray(value)) {
+        merged[key] = [...(merged[key] || []), ...value]
+      } else {
+        merged[key] = value
+      }
+    }
+
+    return merged
+  }
+
+  /**
+   * Generate a cryptographically secure nonce
+   */
+  private generateNonce(): string {
+    return require("crypto").randomBytes(16).toString("base64")
+  }
+
+  /**
+   * Log CSP violation report
+   */
+  logViolation(report: any, req: Request): void {
+    const violation: CspViolationReport = {
+      timestamp: new Date(),
+      userAgent: req.get("User-Agent") || "Unknown",
+      ip: req.ip || req.connection.remoteAddress || "Unknown",
+      violatedDirective: report["violated-directive"] || "Unknown",
+      blockedUri: report["blocked-uri"] || "Unknown",
+      documentUri: report["document-uri"] || "Unknown",
+      originalPolicy: report["original-policy"] || "Unknown",
+      disposition: report.disposition || "enforce",
+      statusCode: report["status-code"] || 0,
+    }
+
+    this.violationReports.push(violation)
+
+    // Log the violation
+    this.logger.warn("CSP Violation Detected", {
+      violatedDirective: violation.violatedDirective,
+      blockedUri: violation.blockedUri,
+      documentUri: violation.documentUri,
+      userAgent: violation.userAgent,
+      ip: violation.ip,
+    })
+
+    // Keep only last 1000 reports to prevent memory issues
+    if (this.violationReports.length > 1000) {
+      this.violationReports = this.violationReports.slice(-1000)
+    }
+  }
+
+  /**
+   * Get violation reports
+   */
+  getViolationReports(limit = 100): CspViolationReport[] {
+    return this.violationReports.slice(-limit).reverse()
+  }
+
+  /**
+   * Get violation statistics
+   */
+  getViolationStats(): {
+    total: number
+    byDirective: Record<string, number>
+    byUri: Record<string, number>
+    recent: number
+  } {
+    const now = new Date()
+    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
+
+    const byDirective: Record<string, number> = {}
+    const byUri: Record<string, number> = {}
+    let recent = 0
+
+    for (const report of this.violationReports) {
+      // Count by directive
+      byDirective[report.violatedDirective] = (byDirective[report.violatedDirective] || 0) + 1
+
+      // Count by URI
+      byUri[report.blockedUri] = (byUri[report.blockedUri] || 0) + 1
+
+      // Count recent violations
+      if (report.timestamp > oneHourAgo) {
+        recent++
+      }
+    }
+
+    return {
+      total: this.violationReports.length,
+      byDirective,
+      byUri,
+      recent,
+    }
+  }
+
+  /**
+   * Clear violation reports
+   */
+  clearViolationReports(): void {
+    this.violationReports = []
+    this.logger.log("CSP violation reports cleared")
+  }
+}

--- a/backend/src/csp/decorators/csp-config.decorator.ts
+++ b/backend/src/csp/decorators/csp-config.decorator.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from "@nestjs/common"
+
+export const CspConfig = (config: string) => SetMetadata("cspConfig", config)

--- a/backend/src/csp/decorators/csp-nonce.decorator.ts
+++ b/backend/src/csp/decorators/csp-nonce.decorator.ts
@@ -1,0 +1,6 @@
+import { createParamDecorator, type ExecutionContext } from "@nestjs/common"
+
+export const CspNonce = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
+  const request = ctx.switchToHttp().getRequest()
+  return request.cspNonce
+})

--- a/backend/src/csp/guards/csp-config.guard.ts
+++ b/backend/src/csp/guards/csp-config.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable, type CanActivate, type ExecutionContext } from "@nestjs/common"
+import type { Reflector } from "@nestjs/core"
+
+@Injectable()
+export class CspConfigGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    // This guard can be used to apply different CSP configurations
+    // based on route metadata
+    const cspConfig = this.reflector.get<string>("cspConfig", context.getHandler())
+
+    if (cspConfig) {
+      const request = context.switchToHttp().getRequest()
+      request.cspConfigOverride = cspConfig
+    }
+
+    return true
+  }
+}

--- a/backend/src/csp/types/csp.types.ts
+++ b/backend/src/csp/types/csp.types.ts
@@ -1,0 +1,38 @@
+export interface CspNonceRequest extends Request {
+  cspNonce?: string
+}
+
+export interface CspViolationReport {
+  "document-uri": string
+  referrer: string
+  "violated-directive": string
+  "effective-directive": string
+  "original-policy": string
+  disposition: "enforce" | "report"
+  "blocked-uri": string
+  "line-number"?: number
+  "column-number"?: number
+  "source-file"?: string
+  "status-code": number
+  "script-sample"?: string
+}
+
+export interface CspConfig {
+  reportOnly: boolean
+  directives: {
+    [key: string]: string[] | boolean | string
+  }
+}
+
+export interface CspStats {
+  totalViolations: number
+  recentViolations: number
+  topViolatedDirectives: Array<{
+    directive: string
+    count: number
+  }>
+  topBlockedUris: Array<{
+    uri: string
+    count: number
+  }>
+}


### PR DESCRIPTION
…ller, middleware, and service## Add Content Security Policy (CSP) Middleware

- Added `csp.middleware.ts` and `csp.module.ts` to enforce a secure Content Security Policy.
- Configured CSP headers using Helmet middleware.
- Defined allowed sources for scripts, styles, images, and other resources.
- Enabled monitoring of CSP violations via browser reports.
- Verified correct header application and enforcement through testing.

close #60