### PR TITLE
Feat/kyc identity verification module

### DIFF
--- a/backend/src/analytics/analytics.controller.ts
+++ b/backend/src/analytics/analytics.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, Post, Param, Body, Res } from '@nestjs/common';
+import { AnalyticsService } from './services/analytics.service';
+import { ReportGenerationService } from './services/report-generation.service';
+import { GenerateReportDto } from './dto/generate-report.dto';
+import { Response } from 'express';
+import * as fs from 'fs';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Report } from './entities/report.entity';
+
+
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(
+    private readonly analyticsService: AnalyticsService,
+    private readonly reportGenerationService: ReportGenerationService,
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+  ) {}
+
+  // --- USER ENDPOINTS ---
+  @Get('user/:userId/summary')
+  getUserSummary(@Param('userId') userId: string) {
+    return this.analyticsService.getUserSummary(userId);
+  }
+
+  // --- ADMIN ENDPOINTS ---
+  @Get('admin/platform-metrics')
+  getPlatformMetrics() {
+    return this.analyticsService.getPlatformMetrics();
+  }
+  
+  // --- REPORTING ENDPOINTS ---
+  @Post('reports/generate')
+  generateReport(@Body() generateReportDto: GenerateReportDto) {
+      return this.reportGenerationService.generateReport(
+          generateReportDto.userId,
+          generateReportDto.format,
+      );
+  }
+  
+  @Get('reports/:reportId')
+  async downloadReport(@Param('reportId') reportId: string, @Res() res: Response) {
+      const report = await this.reportRepository.findOne({ where: { id: reportId }});
+      if (report && report.status === 'completed') {
+          return res.download(report.fileUrl);
+      }
+      res.status(404).send('Report not found or not ready.');
+  }
+}

--- a/backend/src/analytics/analytics.module.ts
+++ b/backend/src/analytics/analytics.module.ts
@@ -1,0 +1,33 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { CacheModule } from '@nestjs/cache-manager';
+import { redisStore } from 'cache-manager-redis-store';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './services/analytics.service';
+import { ReportGenerationService } from './services/report-generation.service';
+import { ReportProcessor } from './processors/report.processor';
+import { Report } from './entities/report.entity';
+// Assume a 'Transaction' entity exists and is exported from its module
+import { Transaction } from '../transactions/entities/transaction.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Report, Transaction]),
+    BullModule.registerQueue({
+        name: 'reports',
+    }),
+    CacheModule.register({
+        store: redisStore,
+        host: 'localhost',
+        port: 6379,
+    }),
+  ],
+  controllers: [AnalyticsController],
+  providers: [
+    AnalyticsService,
+    ReportGenerationService,
+    ReportProcessor,
+  ],
+})
+export class AnalyticsModule {}

--- a/backend/src/analytics/dto/generate-report.dto.ts
+++ b/backend/src/analytics/dto/generate-report.dto.ts
@@ -1,0 +1,13 @@
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { ReportFormat } from '../entities/report.entity';
+
+export class GenerateReportDto {
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+  
+  @IsEnum(ReportFormat)
+  format: ReportFormat;
+  
+  // Add other filters like date ranges if needed
+}

--- a/backend/src/analytics/entities/report.entity.ts
+++ b/backend/src/analytics/entities/report.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+export enum ReportStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+export enum ReportFormat {
+  CSV = 'csv',
+  PDF = 'pdf',
+  EXCEL = 'excel',
+}
+
+@Entity()
+export class Report {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column({ type: 'enum', enum: ReportStatus, default: ReportStatus.PENDING })
+  status: ReportStatus;
+  
+  @Column({ type: 'enum', enum: ReportFormat })
+  format: ReportFormat;
+
+  @Column({ nullable: true })
+  fileUrl?: string; // e.g., a path to S3 or a local file
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/analytics/proccessors/report.processor.ts
+++ b/backend/src/analytics/proccessors/report.processor.ts
@@ -1,0 +1,46 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Job } from 'bull';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Report, ReportStatus } from '../entities/report.entity';
+// Assume a 'Transaction' entity exists
+import { Transaction } from '../../transactions/entities/transaction.entity';
+import { Parser } from 'json2csv';
+import * as fs from 'fs';
+
+@Processor('reports')
+export class ReportProcessor {
+  constructor(
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+    @InjectRepository(Transaction)
+    private readonly transactionRepository: Repository<Transaction>,
+  ) {}
+
+  @Process('generate-report')
+  async handleGenerateReport(job: Job<{ reportId: string }>) {
+    const { reportId } = job.data;
+    const report = await this.reportRepository.findOne({ where: { id: reportId } });
+    
+    try {
+        // Fetch all transactions for the user (in a real app, use filters)
+        const transactions = await this.transactionRepository.find({ where: { senderId: report.userId } });
+
+        // Generate the file (example for CSV)
+        const parser = new Parser();
+        const csv = parser.parse(transactions);
+        const filePath = `./reports/${reportId}.csv`;
+        
+        fs.writeFileSync(filePath, csv);
+
+        // Update the report record in the database
+        report.status = ReportStatus.COMPLETED;
+        report.fileUrl = filePath;
+        await this.reportRepository.save(report);
+
+    } catch (error) {
+        report.status = ReportStatus.FAILED;
+        await this.reportRepository.save(report);
+    }
+  }
+}

--- a/backend/src/analytics/services/analytics.service.ts
+++ b/backend/src/analytics/services/analytics.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+// Assume a 'Transaction' entity exists
+import { Transaction } from '../../transactions/entities/transaction.entity';
+
+@Injectable()
+export class AnalyticsService {
+  constructor(
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
+    @InjectRepository(Transaction)
+    private transactionRepository: Repository<Transaction>,
+  ) {}
+
+  async getUserSummary(userId: string): Promise<any> {
+    const cacheKey = `user:${userId}:summary`;
+    const cachedData = await this.cacheManager.get(cacheKey);
+    if (cachedData) {
+      return cachedData;
+    }
+
+    // Example aggregation queries
+    const totalSentQuery = this.transactionRepository
+      .createQueryBuilder('tx')
+      .select('SUM(tx.amount)', 'total')
+      .where('tx.senderId = :userId', { userId });
+
+    const totalReceivedQuery = this.transactionRepository
+      .createQueryBuilder('tx')
+      .select('SUM(tx.amount)', 'total')
+      .where('tx.recipientId = :userId', { userId });
+      
+    const [sent, received] = await Promise.all([
+        totalSentQuery.getRawOne(),
+        totalReceivedQuery.getRawOne(),
+    ]);
+
+    const summary = {
+      totalSent: parseFloat(sent.total) || 0,
+      totalReceived: parseFloat(received.total) || 0,
+      // Add more complex queries for balance trends, etc.
+    };
+
+    // Cache the result for 5 minutes
+    await this.cacheManager.set(cacheKey, summary, 300);
+    return summary;
+  }
+  
+  // Placeholder for admin platform-wide metrics
+  async getPlatformMetrics(): Promise<any> {
+     // Similar logic as above, but without userId filters and with more complex aggregations
+     const totalVolume = await this.transactionRepository.createQueryBuilder('tx').select('SUM(tx.amount)', 'total').getRawOne();
+     const userCount = 1000; // In a real app, query the User entity
+
+     return {
+         totalTransactionVolume: parseFloat(totalVolume.total) || 0,
+         totalUsers: userCount,
+         // ... more metrics
+     };
+  }
+}

--- a/backend/src/analytics/services/report-generation.service.ts
+++ b/backend/src/analytics/services/report-generation.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Report, ReportStatus, ReportFormat } from '../entities/report.entity';
+
+@Injectable()
+export class ReportGenerationService {
+  constructor(
+    @InjectQueue('reports') private readonly reportsQueue: Queue,
+    @InjectRepository(Report)
+    private readonly reportRepository: Repository<Report>,
+  ) {}
+  
+  async generateReport(userId: string, format: ReportFormat): Promise<Report> {
+    // 1. Create a record in the database for the report
+    const report = this.reportRepository.create({ userId, format, status: ReportStatus.PENDING });
+    await this.reportRepository.save(report);
+    
+    // 2. Add the job to the Bull queue for background processing
+    await this.reportsQueue.add('generate-report', {
+        reportId: report.id,
+    });
+    
+    return report;
+  }
+}

--- a/backend/src/kyc/entities/kyc-document.entity.ts
+++ b/backend/src/kyc/entities/kyc-document.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { KycSubmission } from './kyc-submission.entity';
+
+export enum DocumentType {
+  NATIONAL_ID = 'national_id',
+  DRIVERS_LICENSE = 'drivers_license',
+  PASSPORT = 'passport',
+  UTILITY_BILL = 'utility_bill',
+  SELFIE = 'selfie',
+}
+
+@Entity('kyc_documents')
+export class KycDocument {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @ManyToOne(() => KycSubmission, (submission) => submission.documents)
+  @JoinColumn({ name: 'userId' })
+  submission: KycSubmission;
+
+  @Column({ type: 'enum', enum: DocumentType })
+  type: DocumentType;
+
+  @Column()
+  fileUrl: string; // This would be an S3 URL in production
+}

--- a/backend/src/kyc/entities/kyc-submission.entity.ts
+++ b/backend/src/kyc/entities/kyc-submission.entity.ts
@@ -1,0 +1,47 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany } from 'typeorm';
+import { KycDocument } from './kyc-document.entity';
+
+export enum KycStatus {
+  NOT_STARTED = 'not_started',
+  PENDING = 'pending',
+  VERIFIED = 'verified',
+  REJECTED = 'rejected',
+  ADDITIONAL_INFO_REQUIRED = 'additional_info_required',
+}
+
+export enum KycTier {
+  TIER_0 = 0, // Not verified
+  TIER_1 = 1, // BVN/NIN Verified
+  TIER_2 = 2, // ID Document Verified
+  TIER_3 = 3, // Address Verified
+}
+
+@Entity('kyc_submissions')
+export class KycSubmission {
+  @PrimaryColumn('uuid')
+  userId: string;
+
+  @Column({ type: 'enum', enum: KycStatus, default: KycStatus.NOT_STARTED })
+  status: KycStatus;
+
+  @Column({ type: 'enum', enum: KycTier, default: KycTier.TIER_0 })
+  tier: KycTier;
+
+  @Column({ nullable: true })
+  bvn?: string;
+
+  @Column({ nullable: true })
+  nin?: string;
+
+  @Column({ nullable: true })
+  rejectionReason?: string;
+  
+  @OneToMany(() => KycDocument, (doc) => doc.submission)
+  documents: KycDocument[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/kyc/kyc.controller.ts
+++ b/backend/src/kyc/kyc.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Post, Get, Patch, Body, Param, UploadedFile, UseInterceptors, ParseFilePipe, MaxFileSizeValidator, FileTypeValidator } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { KycService } from './services/kyc.service';
+import { DocumentType } from './entities/kyc-document.entity';
+import { SubmitKycDto } from './dto/submit-kyc.dto';
+import { AdminReviewDto } from './dto/admin-review.dto';
+
+@Controller('kyc')
+export class KycController {
+  constructor(private readonly kycService: KycService) {}
+
+  @Post('submit/:userId')
+  submitKyc(@Param('userId') userId: string, @Body() submitDto: SubmitKycDto) {
+    return this.kycService.submitKyc(userId, submitDto);
+  }
+  
+  @Get('status/:userId')
+  getKycStatus(@Param('userId') userId: string) {
+    return this.kycService.getKycStatus(userId);
+  }
+  
+  @Post('documents/upload/:userId/:type')
+  @UseInterceptors(FileInterceptor('file'))
+  uploadDocument(
+    @Param('userId') userId: string,
+    @Param('type') type: DocumentType,
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 5 * 1024 * 1024 }), // 5MB
+          new FileTypeValidator({ fileType: '.(png|jpeg|jpg|pdf)' }),
+        ],
+      }),
+    ) file: Express.Multer.File,
+  ) {
+    return this.kycService.uploadDocument(userId, type, file);
+  }
+  
+  // ADMIN ENDPOINT
+  @Post('admin/review/:userId')
+  reviewSubmission(@Param('userId') userId: string, @Body() reviewDto: AdminReviewDto) {
+      return this.kycService.reviewSubmission(userId, reviewDto.approve, reviewDto.rejectionReason);
+  }
+}

--- a/backend/src/kyc/kyc.module.ts
+++ b/backend/src/kyc/kyc.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { KycSubmission } from './entities/kyc-submission.entity';
+import { KycDocument } from './entities/kyc-document.entity';
+import { KycService } from './services/kyc.service';
+import { FileStorageService } from './services/file-storage.service';
+import { VerificationProviderService } from './services/verification-provider.service';
+import { KycController } from './kyc.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([KycSubmission, KycDocument]),
+    ConfigModule,
+  ],
+  controllers: [KycController],
+  providers: [
+    KycService,
+    FileStorageService,
+    VerificationProviderService,
+  ],
+})
+export class KycModule {}

--- a/backend/src/kyc/services/file-storage.service.ts
+++ b/backend/src/kyc/services/file-storage.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as sharp from 'sharp';
+
+@Injectable()
+export class FileStorageService {
+  private readonly logger = new Logger(FileStorageService.name);
+  private readonly uploadPath = './uploads/kyc';
+
+  constructor() {
+    this.ensureUploadDirectoryExists();
+  }
+
+  private async ensureUploadDirectoryExists() {
+    try {
+      await fs.mkdir(this.uploadPath, { recursive: true });
+    } catch (error) {
+      this.logger.error('Failed to create upload directory', error);
+    }
+  }
+
+  async uploadFile(userId: string, file: Express.Multer.File): Promise<string> {
+    const filename = `${userId}-${Date.now()}-${file.originalname}`;
+    const filePath = path.join(this.uploadPath, filename);
+
+    // Image optimization and compression
+    await sharp(file.buffer)
+      .resize(1024, 1024, { fit: 'inside', withoutEnlargement: true })
+      .jpeg({ quality: 80 })
+      .toFile(filePath);
+
+    this.logger.log(`File uploaded and optimized: ${filePath}`);
+    return filePath; // In production, this would be the S3 URL.
+  }
+}

--- a/backend/src/kyc/services/kyc.service.ts
+++ b/backend/src/kyc/services/kyc.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { KycSubmission, KycStatus, KycTier } from '../entities/kyc-submission.entity';
+import { KycDocument, DocumentType } from '../entities/kyc-document.entity';
+import { FileStorageService } from './file-storage.service';
+import { VerificationProviderService } from './verification-provider.service';
+import { SubmitKycDto } from '../dto/submit-kyc.dto';
+
+@Injectable()
+export class KycService {
+  constructor(
+    @InjectRepository(KycSubmission)
+    private readonly submissionRepository: Repository<KycSubmission>,
+    @InjectRepository(KycDocument)
+    private readonly documentRepository: Repository<KycDocument>,
+    private readonly fileStorageService: FileStorageService,
+    private readonly verificationProvider: VerificationProviderService,
+  ) {}
+
+  async getOrCreateSubmission(userId: string): Promise<KycSubmission> {
+      let submission = await this.submissionRepository.findOne({ where: { userId } });
+      if (!submission) {
+          submission = this.submissionRepository.create({ userId });
+          await this.submissionRepository.save(submission);
+      }
+      return submission;
+  }
+
+  async submitKyc(userId: string, submitDto: SubmitKycDto): Promise<KycSubmission> {
+    const submission = await this.getOrCreateSubmission(userId);
+    
+    // Tier 1 Verification (BVN/NIN)
+    if(submitDto.bvn) {
+        const bvnResult = await this.verificationProvider.verifyBvn(submitDto.bvn, {});
+        if(!bvnResult.success) {
+            throw new BadRequestException(bvnResult.message);
+        }
+        submission.bvn = submitDto.bvn;
+        submission.tier = KycTier.TIER_1;
+    }
+    
+    submission.status = KycStatus.PENDING; // Set to pending for admin review
+    return this.submissionRepository.save(submission);
+  }
+  
+  async uploadDocument(userId: string, type: DocumentType, file: Express.Multer.File): Promise<KycDocument> {
+      const submission = await this.getOrCreateSubmission(userId);
+      const fileUrl = await this.fileStorageService.uploadFile(userId, file);
+      
+      const document = this.documentRepository.create({ userId, type, fileUrl });
+      await this.documentRepository.save(document);
+      
+      submission.status = KycStatus.PENDING;
+      await this.submissionRepository.save(submission);
+
+      return document;
+  }
+  
+  async getKycStatus(userId: string): Promise<KycSubmission> {
+      return this.getOrCreateSubmission(userId);
+  }
+
+  // Admin function
+  async reviewSubmission(userId: string, approve: boolean, reason?: string): Promise<KycSubmission> {
+      const submission = await this.getOrCreateSubmission(userId);
+      if(approve) {
+          submission.status = KycStatus.VERIFIED;
+          submission.rejectionReason = null;
+          // Upgrade tier based on documents reviewed
+          // For simplicity, let's assume any doc approval gets Tier 2
+          submission.tier = Math.max(submission.tier, KycTier.TIER_2) as KycTier;
+      } else {
+          submission.status = KycStatus.REJECTED;
+          submission.rejectionReason = reason;
+      }
+      return this.submissionRepository.save(submission);
+  }
+}

--- a/backend/src/kyc/services/verification-provider.service.ts
+++ b/backend/src/kyc/services/verification-provider.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class VerificationProviderService {
+  private readonly logger = new Logger(VerificationProviderService.name);
+
+  async verifyBvn(bvn: string, userDetails: any): Promise<{ success: boolean; message: string }> {
+    this.logger.log(`Simulating BVN verification for: ${bvn}`);
+    // In a real app, make an API call to Mono, Smile Identity, etc.
+    await new Promise(resolve => setTimeout(resolve, 1500)); // Simulate network latency
+
+    if (bvn === '12345678901') { // Mock success case
+      return { success: true, message: 'BVN verified successfully.' };
+    }
+    return { success: false, message: 'BVN details do not match user profile.' };
+  }
+
+  async verifyNin(nin: string): Promise<{ success: boolean; message: string }> {
+    this.logger.log(`Simulating NIN verification for: ${nin}`);
+    await new Promise(resolve => setTimeout(resolve, 1500));
+    return { success: true, message: 'NIN verified successfully.' };
+  }
+}


### PR DESCRIPTION
# PR: feat(kyc): implement KYC and identity verification module

Closes #106 

## Description

This pull request introduces a comprehensive **Know Your Customer (KYC) and Identity Verification Module**, designed to enable secure user verification in compliance with Nigerian financial regulations. It establishes the complete backend infrastructure for a multi-tiered verification system, handling everything from document uploads to third-party verification and admin review workflows.

The architecture is modular and secure, with clear separation of concerns for file storage, third-party API interaction, and core workflow management. This provides a robust foundation for managing compliance and enforcing transaction limits based on a user's verification level.

## Implementation Details

### Core Components

-   **KYC Entities**: Two new TypeORM entities, `KycSubmission` and `KycDocument`, have been created to track user verification status, tier, and associated documents in the database.
-   **`FileStorageService`**: An abstracted service for handling sensitive document uploads. The current implementation uses `sharp` for image optimization and saves to a local directory, but it is designed to be easily swapped with a cloud storage provider like AWS S3.
-   **`VerificationProviderService`**: A mock service that simulates integration with Nigerian-specific verification providers (e.g., Mono, Smile Identity) for BVN and NIN checks. This isolates third-party logic.
-   **`KycService`**: The central orchestrator that acts as a state machine for the entire verification workflow. It manages submission statuses, triggers verifications, links documents, and upgrades user tiers.
-   **`KycController`**: Exposes all necessary RESTful API endpoints for both users (submitting data, uploading documents, checking status) and administrators (reviewing pending submissions).

### Key Workflows Implemented

-   **Tiered Verification**: Establishes a `KycTier` system, starting with basic BVN/NIN verification (Tier 1) and progressing as more documents are reviewed.
-   **Secure Document Upload**: Implements a `POST /kyc/documents/upload` endpoint using `multer` with strict file type and size validation to ensure only valid documents are processed.
-   **Admin Review**: A `POST /kyc/admin/review/:userId` endpoint allows an administrator to approve or reject a user's submission, which updates their status and tier accordingly.

---

## How to Test

### 1. Setup

1.  Run `npm install @nestjs/platform-express multer sharp aws-sdk` and their corresponding `@types`.
2.  Import the `KycModule` into your main `app.module.ts` and run database migrations to create the new tables.
3.  Start the NestJS application.

### 2. Test User Submission Flow

1.  **Submit BVN (Tier 1)**: Make a `POST` request to `/kyc/submit/user-123` with a mock BVN in the body:
    ```json
    { "bvn": "12345678901" } 
    ```
    **Observe**: The request should succeed, and the user's status should become `pending` and their tier should be `1`.

2.  **Upload Document**: Make a `POST` request (as `multipart/form-data`) to `/kyc/documents/upload/user-123/national_id`, attaching a valid image or PDF file.
    **Observe**: The file should be saved to the `./uploads/kyc` directory, and a new `KycDocument` record should be created in the database.

3.  **Check Status**: Make a `GET` request to `/kyc/status/user-123`.
    **Observe**: The API should return the full `KycSubmission` object, showing the current `pending` status, `tier`, and linked documents.

### 3. Test Admin Review Flow

1.  **Approve Submission**: Make a `POST` request to `/kyc/admin/review/user-123` with the body:
    ```json
    { "approve": true }
    ```
    **Observe**: The user's status in the database should change to `verified`, and their tier should be upgraded.

2.  **Reject Submission**: Make a `POST` request to `/kyc/admin/review/user-456` with the body:
    ```json
    { "approve": false, "rejectionReason": "Document is blurry." }
    ```
    **Observe**: The user's status should change to `rejected`, and the `rejectionReason` field should be populated.