### PR TITLE
feat: add Admin Dashboard Metrics and Management API

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { UsersModule } from './modules/users/users.module';
 import { FeesModule } from './modules/fee/fee.module';
 import { ReconciliationModule } from './modules/reconciliation/reconciliation.module';
 import { SecretsModule } from './modules/secrets/secrets.module';
+import { AdminModule } from './modules/admin/admin.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { SecretsModule } from './modules/secrets/secrets.module';
     ReconciliationModule,
     FeesModule,
     SecretsModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/modules/admin/admin.controller.ts
+++ b/src/modules/admin/admin.controller.ts
@@ -1,0 +1,162 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Param,
+  Body,
+  Query,
+  ParseUUIDPipe,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { SuspendUserDto } from './dto/suspend-user.dto';
+import { ToggleFeatureFlagDto } from './dto/toggle-feature-flag.dto';
+import { RetryJobControlDto } from './dto/retry-job-control.dto';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { AuditLog } from '../admin-audit/decorators/audit-log.decorator';
+import { SkipAudit } from '../admin-audit/decorators/skip-audit.decorator';
+
+@Controller('admin')
+@UseGuards(AdminGuard)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  // ---------------------------------------------------------------------------
+  // Metrics
+  // ---------------------------------------------------------------------------
+
+  @Get('metrics')
+  @SkipAudit()
+  getMetrics() {
+    return this.adminService.getMetrics();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Users
+  // ---------------------------------------------------------------------------
+
+  @Patch('users/:id/suspend')
+  @AuditLog({
+    action: 'SUSPEND_USER',
+    entity: 'User',
+    entityIdParam: 'id',
+    description: 'Admin updated user suspension status',
+  })
+  suspendUser(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: SuspendUserDto,
+    @Request() req: any,
+  ) {
+    const adminId = req.user?.id ?? 'system';
+    return this.adminService.suspendUser(id, dto, adminId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Transactions
+  // ---------------------------------------------------------------------------
+
+  @Get('transactions')
+  @SkipAudit()
+  getTransactions(
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+    @Query('status') status?: string,
+  ) {
+    return this.adminService.getTransactions(
+      Number(page),
+      Number(limit),
+      status,
+    );
+  }
+
+  @Get('transactions/:id')
+  @SkipAudit()
+  getTransaction(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.adminService.getTransactionById(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Feature flags
+  // ---------------------------------------------------------------------------
+
+  @Get('feature-flags')
+  @SkipAudit()
+  getFeatureFlags() {
+    return this.adminService.getFeatureFlags();
+  }
+
+  @Patch('feature-flags/:id/toggle')
+  @AuditLog({
+    action: 'TOGGLE_FEATURE_FLAG',
+    entity: 'FeatureFlag',
+    entityIdParam: 'id',
+    description: 'Admin toggled a feature flag',
+  })
+  toggleFeatureFlag(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: ToggleFeatureFlagDto,
+  ) {
+    return this.adminService.toggleFeatureFlag(id, dto);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Retry jobs
+  // ---------------------------------------------------------------------------
+
+  @Get('retry-jobs')
+  @SkipAudit()
+  getRetryJobs(
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+    @Query('status') status?: string,
+  ) {
+    return this.adminService.getRetryJobs(Number(page), Number(limit), status);
+  }
+
+  @Patch('retry-jobs/:id/control')
+  @AuditLog({
+    action: 'CONTROL_RETRY_JOB',
+    entity: 'RetryJob',
+    entityIdParam: 'id',
+    description: 'Admin updated retry job status',
+  })
+  controlRetryJob(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: RetryJobControlDto,
+  ) {
+    return this.adminService.controlRetryJob(id, dto);
+  }
+
+  @Post('retry-jobs/:id/trigger')
+  @AuditLog({
+    action: 'TRIGGER_RETRY_JOB',
+    entity: 'RetryJob',
+    entityIdParam: 'id',
+    description: 'Admin manually triggered a retry job',
+  })
+  triggerRetryJob(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.adminService.triggerRetryJob(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Audit logs
+  // ---------------------------------------------------------------------------
+
+  @Get('audit-logs')
+  @SkipAudit()
+  getAuditLogs(
+    @Query('page') page = 1,
+    @Query('limit') limit = 20,
+    @Query('actorId') actorId?: string,
+    @Query('action') action?: string,
+  ) {
+    return this.adminService.getAuditLogs(
+      Number(page),
+      Number(limit),
+      actorId,
+      action,
+    );
+  }
+}

--- a/src/modules/admin/admin.module.ts
+++ b/src/modules/admin/admin.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { TransactionEntity } from '../transactions/entities/transaction.entity';
+import { FeatureFlagEntity } from '../feature-flags/entities/feature-flag.entity';
+import { RetryJobEntity } from '../retry/entities/retry-job.entity';
+import { AdminAuditLogEntity } from '../admin-audit/entities/admin-audit-log.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      TransactionEntity,
+      FeatureFlagEntity,
+      RetryJobEntity,
+      AdminAuditLogEntity,
+    ]),
+  ],
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/src/modules/admin/admin.service.ts
+++ b/src/modules/admin/admin.service.ts
@@ -1,0 +1,232 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TransactionEntity } from '../transactions/entities/transaction.entity';
+import { FeatureFlagEntity } from '../feature-flags/entities/feature-flag.entity';
+import { RetryJobEntity } from '../retry/entities/retry-job.entity';
+import { AdminAuditLogEntity } from '../admin-audit/entities/admin-audit-log.entity';
+import { SuspendUserDto } from './dto/suspend-user.dto';
+import { ToggleFeatureFlagDto } from './dto/toggle-feature-flag.dto';
+import { RetryJobControlDto } from './dto/retry-job-control.dto';
+
+@Injectable()
+export class AdminService {
+  private readonly logger = new Logger(AdminService.name);
+
+  constructor(
+    @InjectRepository(TransactionEntity)
+    private readonly transactionRepo: Repository<TransactionEntity>,
+
+    @InjectRepository(FeatureFlagEntity)
+    private readonly featureFlagRepo: Repository<FeatureFlagEntity>,
+
+    @InjectRepository(RetryJobEntity)
+    private readonly retryJobRepo: Repository<RetryJobEntity>,
+
+    @InjectRepository(AdminAuditLogEntity)
+    private readonly auditLogRepo: Repository<AdminAuditLogEntity>,
+  ) {}
+
+  // ---------------------------------------------------------------------------
+  // Metrics
+  // ---------------------------------------------------------------------------
+
+  async getMetrics() {
+    const [
+      totalTransactions,
+      pendingTransactions,
+      failedTransactions,
+      totalRetryJobs,
+      pendingRetryJobs,
+      failedRetryJobs,
+      totalFeatureFlags,
+      enabledFeatureFlags,
+      recentAuditLogs,
+    ] = await Promise.all([
+      this.transactionRepo.count(),
+      this.transactionRepo.count({ where: { status: 'pending' } }),
+      this.transactionRepo.count({ where: { status: 'failed' } }),
+      this.retryJobRepo.count(),
+      this.retryJobRepo.count({ where: { status: 'pending' } }),
+      this.retryJobRepo.count({ where: { status: 'failed' } }),
+      this.featureFlagRepo.count(),
+      this.featureFlagRepo.count({ where: { enabled: true } }),
+      this.auditLogRepo.count(),
+    ]);
+
+    return {
+      transactions: {
+        total: totalTransactions,
+        pending: pendingTransactions,
+        failed: failedTransactions,
+      },
+      retryJobs: {
+        total: totalRetryJobs,
+        pending: pendingRetryJobs,
+        failed: failedRetryJobs,
+      },
+      featureFlags: {
+        total: totalFeatureFlags,
+        enabled: enabledFeatureFlags,
+      },
+      auditLogs: {
+        total: recentAuditLogs,
+      },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // User suspension
+  // ---------------------------------------------------------------------------
+
+  async suspendUser(userId: string, dto: SuspendUserDto, adminId: string) {
+    // Update all active transactions for this user to reflect suspension if needed.
+    // The user entity itself is expected to be managed by the UsersService / UsersModule.
+    // Here we delegate to a raw update so we don't need to import the UserEntity directly
+    // — which avoids circular dependencies. If you have a UsersService exported you can
+    // inject it instead.
+    const result = await this.transactionRepo.manager.query(
+      `UPDATE users SET is_suspended = $1, suspension_reason = $2, updated_at = NOW() WHERE id = $3 RETURNING id`,
+      [dto.suspended, dto.reason ?? null, userId],
+    );
+
+    if (!result[1] || result[1] === 0) {
+      throw new NotFoundException(`User with id ${userId} not found`);
+    }
+
+    const action = dto.suspended ? 'SUSPEND_USER' : 'UNSUSPEND_USER';
+    this.logger.log(`Admin ${adminId} performed ${action} on user ${userId}`);
+
+    return {
+      userId,
+      suspended: dto.suspended,
+      reason: dto.reason,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Transactions oversight
+  // ---------------------------------------------------------------------------
+
+  async getTransactions(page = 1, limit = 20, status?: string) {
+    const qb = this.transactionRepo
+      .createQueryBuilder('tx')
+      .orderBy('tx.createdAt', 'DESC');
+
+    if (status) {
+      qb.where('tx.status = :status', { status });
+    }
+
+    const [data, total] = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    return { data, total, page, limit };
+  }
+
+  async getTransactionById(id: string) {
+    const tx = await this.transactionRepo.findOne({ where: { id } });
+    if (!tx) throw new NotFoundException(`Transaction ${id} not found`);
+    return tx;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Feature flag toggle
+  // ---------------------------------------------------------------------------
+
+  async toggleFeatureFlag(id: string, dto: ToggleFeatureFlagDto) {
+    const flag = await this.featureFlagRepo.findOne({ where: { id } });
+    if (!flag) throw new NotFoundException(`Feature flag ${id} not found`);
+
+    flag.enabled = dto.enabled;
+    const updated = await this.featureFlagRepo.save(flag);
+
+    this.logger.log(`Feature flag ${flag.name} toggled to ${dto.enabled}`);
+    return updated;
+  }
+
+  async getFeatureFlags() {
+    return this.featureFlagRepo.find({ order: { name: 'ASC' } });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Retry job control
+  // ---------------------------------------------------------------------------
+
+  async getRetryJobs(page = 1, limit = 20, status?: string) {
+    const qb = this.retryJobRepo
+      .createQueryBuilder('job')
+      .orderBy('job.createdAt', 'DESC');
+
+    if (status) {
+      qb.where('job.status = :status', { status });
+    }
+
+    const [data, total] = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    return { data, total, page, limit };
+  }
+
+  async controlRetryJob(id: string, dto: RetryJobControlDto) {
+    const job = await this.retryJobRepo.findOne({ where: { id } });
+    if (!job) throw new NotFoundException(`Retry job ${id} not found`);
+
+    if (job.status === 'succeeded' || job.status === 'running') {
+      throw new BadRequestException(
+        `Cannot change status of a job that is ${job.status}`,
+      );
+    }
+
+    job.status = dto.status;
+    const updated = await this.retryJobRepo.save(job);
+
+    this.logger.log(`Retry job ${id} status updated to ${dto.status}`);
+    return updated;
+  }
+
+  async triggerRetryJob(id: string) {
+    const job = await this.retryJobRepo.findOne({ where: { id } });
+    if (!job) throw new NotFoundException(`Retry job ${id} not found`);
+
+    if (job.status === 'running') {
+      throw new BadRequestException('Job is already running');
+    }
+
+    job.status = 'pending';
+    job.nextRunAt = new Date();
+    const updated = await this.retryJobRepo.save(job);
+
+    this.logger.log(`Retry job ${id} manually triggered`);
+    return updated;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Audit logs
+  // ---------------------------------------------------------------------------
+
+  async getAuditLogs(page = 1, limit = 20, actorId?: string, action?: string) {
+    const qb = this.auditLogRepo
+      .createQueryBuilder('log')
+      .orderBy('log.createdAt', 'DESC');
+
+    if (actorId) qb.andWhere('log.actorId = :actorId', { actorId });
+    if (action)
+      qb.andWhere('log.action ILIKE :action', { action: `%${action}%` });
+
+    const [data, total] = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    return { data, total, page, limit };
+  }
+}

--- a/src/modules/admin/dto/retry-job-control.dto.ts
+++ b/src/modules/admin/dto/retry-job-control.dto.ts
@@ -1,0 +1,6 @@
+import { IsIn, IsOptional } from 'class-validator';
+
+export class RetryJobControlDto {
+  @IsIn(['pending', 'cancelled'])
+  status: 'pending' | 'cancelled';
+}

--- a/src/modules/admin/dto/suspend-user.dto.ts
+++ b/src/modules/admin/dto/suspend-user.dto.ts
@@ -1,0 +1,10 @@
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class SuspendUserDto {
+  @IsBoolean()
+  suspended: boolean;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/src/modules/admin/dto/toggle-feature-flag.dto.ts
+++ b/src/modules/admin/dto/toggle-feature-flag.dto.ts
@@ -1,0 +1,6 @@
+import { IsBoolean } from 'class-validator';
+
+export class ToggleFeatureFlagDto {
+  @IsBoolean()
+  enabled: boolean;
+}


### PR DESCRIPTION
## Description

Implements a centralized Admin Dashboard Metrics and Management API that unifies platform control under a single `admin` module. This provides a single place for monitoring platform health, managing users, overseeing transactions, toggling feature flags, and controlling retry jobs, all with full audit logging.

## Related Issue

- Closes #179 

## Changes Made

- Created `src/modules/admin/admin.module.ts` with TypeORM feature registrations for transactions, feature flags, retry jobs, and audit logs.
- Created `src/modules/admin/admin.service.ts` with service methods covering metrics aggregation, user suspension, transaction oversight, feature flag toggling, retry job control, and audit log querying.
- Created `src/modules/admin/admin.controller.ts` exposing all admin endpoints under the `/admin` prefix, protected by `AdminGuard` and decorated with `@AuditLog` for write operations.
- Added DTOs: `SuspendUserDto`, `ToggleFeatureFlagDto`, `RetryJobControlDto`.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | /admin/metrics | Aggregated platform metrics |
| PATCH | /admin/users/:id/suspend | Suspend or unsuspend a user |
| GET | /admin/transactions | Paginated transaction list with optional status filter |
| GET | /admin/transactions/:id | Single transaction detail |
| GET | /admin/feature-flags | List all feature flags |
| PATCH | /admin/feature-flags/:id/toggle | Enable or disable a feature flag |
| GET | /admin/retry-jobs | Paginated retry job list with optional status filter |
| PATCH | /admin/retry-jobs/:id/control | Set retry job status to pending or cancelled |
| POST | /admin/retry-jobs/:id/trigger | Manually trigger a retry job |
| GET | /admin/audit-logs | Paginated audit log list with optional filters |