### PR TITLE
feat: Add webhook signature verification

### DIFF
--- a/src/modules/webhooks/controllers/webhook-inbound.controller.ts
+++ b/src/modules/webhooks/controllers/webhook-inbound.controller.ts
@@ -1,0 +1,36 @@
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  Logger,
+  Post,
+  RawBodyRequest,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { WebhookSignatureGuard } from '../guards/webhook-signature.guard';
+import { SkipAudit } from '../../admin-audit/decorators/skip-audit.decorator';
+
+@Controller('webhooks/inbound')
+export class WebhookInboundController {
+  private readonly logger = new Logger(WebhookInboundController.name);
+
+  @Post()
+  @HttpCode(200)
+  @UseGuards(WebhookSignatureGuard)
+  @SkipAudit()
+  receive(
+    @Req() req: RawBodyRequest<Request>,
+    @Headers('x-nexafx-event') eventName: string,
+    @Headers('x-nexafx-delivery-id') deliveryId: string,
+    @Body() payload: Record<string, any>,
+  ) {
+    this.logger.log(
+      `Verified inbound webhook received: event=${eventName} deliveryId=${deliveryId}`,
+    );
+
+    return { received: true };
+  }
+}

--- a/src/modules/webhooks/entities/webhook-inbound-log.entity.ts
+++ b/src/modules/webhooks/entities/webhook-inbound-log.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export type WebhookVerificationStatus = 'accepted' | 'rejected';
+
+export type WebhookRejectionReason =
+  | 'MISSING_HEADERS'
+  | 'INVALID_SIGNATURE'
+  | 'TIMESTAMP_TOO_OLD'
+  | 'REPLAY_DETECTED'
+  | null;
+
+@Entity('webhook_inbound_logs')
+@Index('idx_wh_inbound_delivery_id', ['deliveryId'], { unique: true })
+@Index('idx_wh_inbound_status', ['status'])
+@Index('idx_wh_inbound_created_at', ['createdAt'])
+export class WebhookInboundLogEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // The x-nexafx-delivery-id sent by the caller — used for replay detection
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  deliveryId?: string;
+
+  @Column({ type: 'varchar', length: 45, nullable: true })
+  ipAddress?: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  eventName?: string;
+
+  @Column({
+    type: 'enum',
+    enum: ['accepted', 'rejected'],
+    default: 'accepted',
+  })
+  status: WebhookVerificationStatus;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  rejectionReason?: WebhookRejectionReason;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  receivedSignature?: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  timestamp?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/modules/webhooks/guards/webhook-signature.guard.ts
+++ b/src/modules/webhooks/guards/webhook-signature.guard.ts
@@ -1,0 +1,102 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { WebhookVerificationService } from '../services/webhook-verification.service';
+import { WebhooksService } from '../webhooks.service';
+
+const REQUIRED_HEADERS = [
+  'x-nexafx-signature',
+  'x-nexafx-timestamp',
+  'x-nexafx-delivery-id',
+];
+
+@Injectable()
+export class WebhookSignatureGuard implements CanActivate {
+  private readonly logger = new Logger(WebhookSignatureGuard.name);
+
+  constructor(
+    private readonly verificationService: WebhookVerificationService,
+    private readonly webhooksService: WebhooksService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const signature = request.headers['x-nexafx-signature'];
+    const timestamp = request.headers['x-nexafx-timestamp'];
+    const deliveryId = request.headers['x-nexafx-delivery-id'];
+    const eventName = request.headers['x-nexafx-event'];
+
+    // Check all required headers are present
+    const missing = REQUIRED_HEADERS.filter((h) => !request.headers[h]);
+    if (missing.length > 0) {
+      this.logger.warn(
+        `Webhook request missing headers: ${missing.join(', ')}`,
+      );
+      throw new UnauthorizedException(
+        `Missing required webhook headers: ${missing.join(', ')}`,
+      );
+    }
+
+    // Raw body must be available. NestJS parses JSON by default — we need the raw buffer.
+    // This is populated by the rawBodyMiddleware registered in main.ts.
+    const rawBody: Buffer | undefined = request.rawBody;
+    if (!rawBody) {
+      this.logger.error(
+        'rawBody is not available — ensure rawBodyMiddleware is applied to the webhooks route',
+      );
+      throw new UnauthorizedException(
+        'Unable to verify webhook signature: raw body unavailable',
+      );
+    }
+
+    const rawBodyString = rawBody.toString('utf8');
+
+    // Look up the subscription secret by delivery ID (via subscription ID embedded in delivery)
+    // The secret to verify against is scoped per subscription. Since inbound webhooks reference
+    // a subscriptionId via deliveryId, we look up the delivery to find the subscription secret.
+    // Fall back to a global shared secret if configured.
+    const secret = await this.resolveSecret(deliveryId);
+
+    if (!secret) {
+      this.logger.warn(`No secret found for deliveryId=${deliveryId}`);
+      throw new UnauthorizedException('Unable to resolve webhook secret');
+    }
+
+    const ipAddress =
+      request.ip ||
+      request.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+      'unknown';
+
+    const result = await this.verificationService.verify({
+      signature,
+      timestamp,
+      deliveryId,
+      rawBody: rawBodyString,
+      secret,
+      ipAddress,
+      eventName,
+    });
+
+    if (!result.valid) {
+      throw new UnauthorizedException(
+        `Webhook verification failed: ${result.reason}`,
+      );
+    }
+
+    return true;
+  }
+
+  private async resolveSecret(deliveryId: string): Promise<string | null> {
+    // Try to find the subscription linked to this delivery
+    const secret = await this.webhooksService.getSecretByDeliveryId(deliveryId);
+    if (secret) return secret;
+
+    // Fall back to a global shared ingestion secret (env var)
+    return process.env.WEBHOOK_INGESTION_SECRET ?? null;
+  }
+}

--- a/src/modules/webhooks/services/webhook-verification.service.ts
+++ b/src/modules/webhooks/services/webhook-verification.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  WebhookInboundLogEntity,
+  WebhookRejectionReason,
+} from '../entities/webhook-inbound-log.entity';
+import { verifyWebhookSignature } from '../utils/webhook-signature';
+
+// Max age of a webhook timestamp before it is considered stale (5 minutes)
+const TIMESTAMP_TOLERANCE_SECONDS = 300;
+
+export interface VerificationContext {
+  signature: string;
+  timestamp: string;
+  deliveryId: string;
+  rawBody: string;
+  secret: string;
+  ipAddress?: string;
+  eventName?: string;
+}
+
+export interface VerificationResult {
+  valid: boolean;
+  reason?: WebhookRejectionReason;
+}
+
+@Injectable()
+export class WebhookVerificationService {
+  private readonly logger = new Logger(WebhookVerificationService.name);
+
+  constructor(
+    @InjectRepository(WebhookInboundLogEntity)
+    private readonly logRepo: Repository<WebhookInboundLogEntity>,
+  ) {}
+
+  async verify(ctx: VerificationContext): Promise<VerificationResult> {
+    // 1. Timestamp staleness check
+    const tsSeconds = parseInt(ctx.timestamp, 10);
+    if (isNaN(tsSeconds)) {
+      await this.log(ctx, 'rejected', 'MISSING_HEADERS');
+      return { valid: false, reason: 'MISSING_HEADERS' };
+    }
+
+    const ageSeconds = Math.floor(Date.now() / 1000) - tsSeconds;
+    if (ageSeconds > TIMESTAMP_TOLERANCE_SECONDS || ageSeconds < -60) {
+      this.logger.warn(
+        `Webhook rejected — timestamp too old or too far in future: age=${ageSeconds}s deliveryId=${ctx.deliveryId}`,
+      );
+      await this.log(ctx, 'rejected', 'TIMESTAMP_TOO_OLD');
+      return { valid: false, reason: 'TIMESTAMP_TOO_OLD' };
+    }
+
+    // 2. Replay detection — check if this delivery ID has been seen before
+    const existing = await this.logRepo.findOne({
+      where: { deliveryId: ctx.deliveryId, status: 'accepted' },
+    });
+
+    if (existing) {
+      this.logger.warn(
+        `Webhook rejected — replay detected for deliveryId=${ctx.deliveryId}`,
+      );
+      await this.log(ctx, 'rejected', 'REPLAY_DETECTED');
+      return { valid: false, reason: 'REPLAY_DETECTED' };
+    }
+
+    // 3. HMAC signature verification
+    const signatureValid = verifyWebhookSignature(
+      ctx.secret,
+      ctx.timestamp,
+      ctx.rawBody,
+      ctx.signature,
+    );
+
+    if (!signatureValid) {
+      this.logger.warn(
+        `Webhook rejected — invalid signature for deliveryId=${ctx.deliveryId} ip=${ctx.ipAddress}`,
+      );
+      await this.log(ctx, 'rejected', 'INVALID_SIGNATURE');
+      return { valid: false, reason: 'INVALID_SIGNATURE' };
+    }
+
+    // All checks passed — log acceptance
+    await this.log(ctx, 'accepted', null);
+    return { valid: true };
+  }
+
+  private async log(
+    ctx: VerificationContext,
+    status: 'accepted' | 'rejected',
+    reason: WebhookRejectionReason,
+  ): Promise<void> {
+    try {
+      await this.logRepo.save(
+        this.logRepo.create({
+          deliveryId: ctx.deliveryId,
+          ipAddress: ctx.ipAddress,
+          eventName: ctx.eventName,
+          status,
+          rejectionReason: reason,
+          receivedSignature: ctx.signature,
+          timestamp: ctx.timestamp,
+        }),
+      );
+    } catch (err) {
+      this.logger.error('Failed to persist webhook inbound log', err);
+    }
+  }
+
+  async getInboundLogs(
+    page = 1,
+    limit = 20,
+    status?: 'accepted' | 'rejected',
+  ): Promise<{ data: WebhookInboundLogEntity[]; total: number }> {
+    const qb = this.logRepo
+      .createQueryBuilder('log')
+      .orderBy('log.createdAt', 'DESC');
+
+    if (status) {
+      qb.where('log.status = :status', { status });
+    }
+
+    const [data, total] = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    return { data, total };
+  }
+}

--- a/src/modules/webhooks/utils/webhook-signature.ts
+++ b/src/modules/webhooks/utils/webhook-signature.ts
@@ -4,8 +4,32 @@ export function signWebhookPayload(
   secret: string,
   timestamp: string,
   rawBody: string,
-) {
+): string {
   const data = `${timestamp}.${rawBody}`;
   const digest = crypto.createHmac('sha256', secret).update(data).digest('hex');
   return `sha256=${digest}`;
+}
+
+/**
+ * Verifies an inbound webhook signature.
+ * Returns true if the signature is valid, false otherwise.
+ * Uses timing-safe comparison to prevent timing attacks.
+ */
+export function verifyWebhookSignature(
+  secret: string,
+  timestamp: string,
+  rawBody: string,
+  receivedSignature: string,
+): boolean {
+  const expected = signWebhookPayload(secret, timestamp, rawBody);
+
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(expected),
+      Buffer.from(receivedSignature),
+    );
+  } catch {
+    // Buffers of different lengths throw — means signature is definitely wrong
+    return false;
+  }
 }


### PR DESCRIPTION
## Description

Adds HMAC signature verification, timestamp staleness checking, and delivery ID-based replay protection to webhook ingestion. All verification outcomes are persisted to a new `webhook_inbound_logs` table and surfaced through an admin endpoint. This closes the spoofing and replay attack vectors that existed on the unprotected webhook ingestion route.

## Related Issue

- Closes #176 