### PR TITLE
feat: implement issues #449 #450 #451 #452 — notification templates, push infra, SMS multi-channel, WebSocket rooms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "bull": "^4.12.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "handlebars": "^4.7.9",
         "jsonwebtoken": "^9.0.3",
         "nodemailer": "^8.0.4",
         "pg": "^8.11.3",
@@ -8103,10 +8104,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
-      "dev": true,
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -8128,7 +8128,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10489,7 +10488,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -13773,7 +13771,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -14276,7 +14273,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bull": "^4.12.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "handlebars": "^4.7.9",
     "jsonwebtoken": "^9.0.3",
     "nodemailer": "^8.0.4",
     "pg": "^8.11.3",

--- a/src/database/seeds/notification-templates.seed.ts
+++ b/src/database/seeds/notification-templates.seed.ts
@@ -1,0 +1,98 @@
+import { DataSource } from 'typeorm';
+import {
+  NotificationTemplateEntity,
+  TemplateChannel,
+} from '../../modules/notifications/entities/notification-template.entity';
+
+const EMAIL_TEMPLATES = [
+  {
+    name: 'password_reset',
+    channel: TemplateChannel.EMAIL,
+    locale: 'en',
+    subjectTemplate: 'Reset Your Password',
+    bodyTemplate: `<p>Hi,</p><p>Click <a href="{{resetUrl}}">here</a> to reset your password. This link expires in 1 hour.</p>`,
+    requiredVariables: ['resetUrl'],
+  },
+  {
+    name: 'email_verification',
+    channel: TemplateChannel.EMAIL,
+    locale: 'en',
+    subjectTemplate: 'Verify Your Email',
+    bodyTemplate: `<p>Please verify your email by clicking <a href="{{verifyUrl}}">here</a>.</p>`,
+    requiredVariables: ['verifyUrl'],
+  },
+  {
+    name: 'new_device_login',
+    channel: TemplateChannel.EMAIL,
+    locale: 'en',
+    subjectTemplate: 'New Device Login Detected',
+    bodyTemplate: `<p>A new login was detected from IP <strong>{{ip}}</strong> using <em>{{userAgent}}</em>. If this wasn't you, secure your account immediately.</p>`,
+    requiredVariables: ['ip', 'userAgent'],
+  },
+  {
+    name: 'account_locked',
+    channel: TemplateChannel.EMAIL,
+    locale: 'en',
+    subjectTemplate: 'Account Locked',
+    bodyTemplate: `<p>Your account has been locked due to multiple failed login attempts. Please contact support to unlock it.</p>`,
+    requiredVariables: [],
+  },
+  {
+    name: 'transaction_completed',
+    channel: TemplateChannel.EMAIL,
+    locale: 'en',
+    subjectTemplate: 'Transaction Completed — {{amount}} {{currency}}',
+    bodyTemplate: `<p>Your transaction of <strong>{{amount}} {{currency}}</strong> has been completed successfully.</p><p>Transaction ID: {{transactionId}}</p>`,
+    requiredVariables: ['amount', 'currency', 'transactionId'],
+  },
+  {
+    name: 'transaction_failed',
+    channel: TemplateChannel.EMAIL,
+    locale: 'en',
+    subjectTemplate: 'Transaction Failed',
+    bodyTemplate: `<p>Your transaction of <strong>{{amount}} {{currency}}</strong> failed. Reason: {{reason}}.</p>`,
+    requiredVariables: ['amount', 'currency', 'reason'],
+  },
+  {
+    name: 'fraud_alert',
+    channel: TemplateChannel.EMAIL,
+    locale: 'en',
+    subjectTemplate: 'Security Alert: Suspicious Activity Detected',
+    bodyTemplate: `<p>We detected suspicious activity on your account. Transaction ID: {{transactionId}}. Risk score: {{riskScore}}.</p>`,
+    requiredVariables: ['transactionId', 'riskScore'],
+  },
+];
+
+const SMS_TEMPLATES = [
+  {
+    name: 'transaction_completed',
+    channel: TemplateChannel.SMS,
+    locale: 'en',
+    subjectTemplate: null,
+    bodyTemplate: `NexaFx: Transaction {{transactionId}} of {{amount}} {{currency}} completed.`,
+    requiredVariables: ['transactionId', 'amount', 'currency'],
+  },
+  {
+    name: 'fraud_alert',
+    channel: TemplateChannel.SMS,
+    locale: 'en',
+    subjectTemplate: null,
+    bodyTemplate: `NexaFx ALERT: Suspicious activity on your account. Tx: {{transactionId}}. Contact support if not you.`,
+    requiredVariables: ['transactionId'],
+  },
+];
+
+export async function seedNotificationTemplates(dataSource: DataSource): Promise<void> {
+  const repo = dataSource.getRepository(NotificationTemplateEntity);
+
+  const allTemplates = [...EMAIL_TEMPLATES, ...SMS_TEMPLATES];
+
+  for (const tpl of allTemplates) {
+    const exists = await repo.findOne({
+      where: { name: tpl.name, channel: tpl.channel, locale: tpl.locale, isArchived: false },
+    });
+    if (!exists) {
+      await repo.save(repo.create({ ...tpl, version: 1, isArchived: false }));
+    }
+  }
+}

--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -8,14 +8,20 @@ import { RevenueAnalyticsService } from './services/revenue-analytics.service';
 import { RevenueAnalyticsController } from './controllers/revenue-analytics.controller';
 import { AnalyticsAdminController } from './controllers/analytics-admin.controller';
 import { AnalyticsCleanupWorker } from './workers/analytics-cleanup.worker';
+import { NotificationDeliveryAnalyticsController } from './controllers/notification-delivery-analytics.controller';
+import { NotificationDeliveryReceiptEntity } from '../notifications/entities/notification-delivery-receipt.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ApiUsageLogEntity]),
+    TypeOrmModule.forFeature([ApiUsageLogEntity, NotificationDeliveryReceiptEntity]),
     ScheduleModule.forRoot(),
   ],
   providers: [ApiUsageService, AnalyticsCleanupWorker, RevenueAnalyticsService],
-  controllers: [AnalyticsAdminController, RevenueAnalyticsController],
+  controllers: [
+    AnalyticsAdminController,
+    RevenueAnalyticsController,
+    NotificationDeliveryAnalyticsController,
+  ],
   exports: [ApiUsageService, RevenueAnalyticsService],
 })
 export class AnalyticsModule implements NestModule {

--- a/src/modules/analytics/controllers/notification-delivery-analytics.controller.ts
+++ b/src/modules/analytics/controllers/notification-delivery-analytics.controller.ts
@@ -1,0 +1,65 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  NotificationDeliveryReceiptEntity,
+  DeliveryChannel,
+  DeliveryStatus,
+} from '../../notifications/entities/notification-delivery-receipt.entity';
+
+@Controller('admin/analytics/notifications')
+export class NotificationDeliveryAnalyticsController {
+  constructor(
+    @InjectRepository(NotificationDeliveryReceiptEntity)
+    private readonly receiptRepo: Repository<NotificationDeliveryReceiptEntity>,
+  ) {}
+
+  /**
+   * GET /admin/analytics/notifications/delivery
+   * Returns per-channel success rates and counts.
+   */
+  @Get('delivery')
+  async getDeliveryStats(
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    const qb = this.receiptRepo.createQueryBuilder('r');
+
+    if (from) qb.andWhere('r.created_at >= :from', { from: new Date(from) });
+    if (to) qb.andWhere('r.created_at <= :to', { to: new Date(to) });
+
+    const rows = await qb
+      .select('r.channel', 'channel')
+      .addSelect('r.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('r.channel')
+      .addGroupBy('r.status')
+      .getRawMany<{ channel: DeliveryChannel; status: DeliveryStatus; count: string }>();
+
+    // Aggregate into per-channel stats
+    const channelMap: Record<
+      string,
+      { total: number; success: number; failed: number; successRate: number }
+    > = {};
+
+    for (const row of rows) {
+      const ch = row.channel;
+      if (!channelMap[ch]) channelMap[ch] = { total: 0, success: 0, failed: 0, successRate: 0 };
+      const count = parseInt(row.count, 10);
+      channelMap[ch].total += count;
+      if (row.status === DeliveryStatus.SUCCESS) channelMap[ch].success += count;
+      if (row.status === DeliveryStatus.FAILED) channelMap[ch].failed += count;
+    }
+
+    for (const ch of Object.keys(channelMap)) {
+      const s = channelMap[ch];
+      s.successRate = s.total > 0 ? Math.round((s.success / s.total) * 10000) / 100 : 0;
+    }
+
+    return {
+      success: true,
+      data: channelMap,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/src/modules/mail/mail.module.ts
+++ b/src/modules/mail/mail.module.ts
@@ -1,7 +1,9 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { MailService } from './services/mail.service';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
+  imports: [forwardRef(() => NotificationsModule)],
   providers: [MailService],
   exports: [MailService],
 })

--- a/src/modules/mail/services/mail.service.ts
+++ b/src/modules/mail/services/mail.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import * as nodemailer from 'nodemailer';
 import {
@@ -7,13 +7,18 @@ import {
   newDeviceLoginTemplate,
   accountLockedTemplate,
 } from '../templates';
+import { TemplateService } from '../../notifications/services/template.service';
+import { TemplateChannel } from '../../notifications/entities/notification-template.entity';
 
 @Injectable()
 export class MailService {
   private readonly logger = new Logger(MailService.name);
   private transporter: nodemailer.Transporter;
 
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    @Optional() private readonly templateService?: TemplateService,
+  ) {
     this.transporter = nodemailer.createTransport({
       host: this.config.get<string>('MAIL_HOST'),
       port: this.config.get<number>('MAIL_PORT'),
@@ -39,19 +44,74 @@ export class MailService {
     }
   }
 
-  async sendPasswordReset(to: string, resetUrl: string): Promise<void> {
-    await this.send(to, 'Reset Your Password', passwordResetTemplate(resetUrl));
+  /**
+   * Attempt to render a DB template; falls back to the provided hardcoded html.
+   */
+  private async resolveTemplate(
+    name: string,
+    variables: Record<string, unknown>,
+    fallbackSubject: string,
+    fallbackHtml: string,
+    locale = 'en',
+  ): Promise<{ subject: string; html: string }> {
+    if (this.templateService) {
+      try {
+        const tpl = await this.templateService.resolve(name, TemplateChannel.EMAIL, locale);
+        if (tpl) {
+          const rendered = this.templateService.render(tpl, variables);
+          return {
+            subject: rendered.subject ?? fallbackSubject,
+            html: rendered.body,
+          };
+        }
+      } catch (err) {
+        this.logger.warn(`Template "${name}" render failed, using fallback: ${err?.message}`);
+      }
+    }
+    return { subject: fallbackSubject, html: fallbackHtml };
   }
 
-  async sendEmailVerification(to: string, verifyUrl: string): Promise<void> {
-    await this.send(to, 'Verify Your Email', emailVerificationTemplate(verifyUrl));
+  async sendPasswordReset(to: string, resetUrl: string, locale = 'en'): Promise<void> {
+    const { subject, html } = await this.resolveTemplate(
+      'password_reset',
+      { resetUrl },
+      'Reset Your Password',
+      passwordResetTemplate(resetUrl),
+      locale,
+    );
+    await this.send(to, subject, html);
   }
 
-  async sendNewDeviceLogin(to: string, ip: string, userAgent: string): Promise<void> {
-    await this.send(to, 'New Device Login Detected', newDeviceLoginTemplate(ip, userAgent));
+  async sendEmailVerification(to: string, verifyUrl: string, locale = 'en'): Promise<void> {
+    const { subject, html } = await this.resolveTemplate(
+      'email_verification',
+      { verifyUrl },
+      'Verify Your Email',
+      emailVerificationTemplate(verifyUrl),
+      locale,
+    );
+    await this.send(to, subject, html);
   }
 
-  async sendAccountLocked(to: string): Promise<void> {
-    await this.send(to, 'Account Locked', accountLockedTemplate());
+  async sendNewDeviceLogin(to: string, ip: string, userAgent: string, locale = 'en'): Promise<void> {
+    const { subject, html } = await this.resolveTemplate(
+      'new_device_login',
+      { ip, userAgent },
+      'New Device Login Detected',
+      newDeviceLoginTemplate(ip, userAgent),
+      locale,
+    );
+    await this.send(to, subject, html);
+  }
+
+  async sendAccountLocked(to: string, locale = 'en'): Promise<void> {
+    const { subject, html } = await this.resolveTemplate(
+      'account_locked',
+      {},
+      'Account Locked',
+      accountLockedTemplate(),
+      locale,
+    );
+    await this.send(to, subject, html);
   }
 }

--- a/src/modules/notifications/controllers/template-admin.controller.ts
+++ b/src/modules/notifications/controllers/template-admin.controller.ts
@@ -1,0 +1,86 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  IsArray,
+} from 'class-validator';
+import { TemplateService } from '../services/template.service';
+import { TemplateChannel } from '../entities/notification-template.entity';
+
+class CreateTemplateDto {
+  @IsNotEmpty() @IsString() @MaxLength(100) name: string;
+  @IsEnum(TemplateChannel) channel: TemplateChannel;
+  @IsOptional() @IsString() @MaxLength(10) locale?: string;
+  @IsOptional() @IsString() @MaxLength(500) subjectTemplate?: string;
+  @IsNotEmpty() @IsString() bodyTemplate: string;
+  @IsOptional() @IsArray() @IsString({ each: true }) requiredVariables?: string[];
+}
+
+class UpdateTemplateDto {
+  @IsOptional() @IsString() @MaxLength(500) subjectTemplate?: string;
+  @IsOptional() @IsString() bodyTemplate?: string;
+  @IsOptional() @IsArray() @IsString({ each: true }) requiredVariables?: string[];
+}
+
+@Controller('admin/notification-templates')
+export class TemplateAdminController {
+  constructor(private readonly templateService: TemplateService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: CreateTemplateDto) {
+    return this.templateService.create({
+      ...dto,
+      locale: dto.locale ?? 'en',
+    });
+  }
+
+  @Get()
+  findAll() {
+    return this.templateService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.templateService.findOne(id);
+  }
+
+  @Get(':id/preview')
+  async preview(@Param('id') id: string) {
+    const template = await this.templateService.findOne(id);
+    // Build sample data from requiredVariables
+    const sampleData = Object.fromEntries(
+      template.requiredVariables.map((v) => [v, `<${v}>`]),
+    );
+    return this.templateService.render(template, sampleData);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateTemplateDto) {
+    return this.templateService.update(id, dto);
+  }
+
+  @Post(':id/versions/:version/restore')
+  restore(@Param('id') id: string, @Param('version') version: string) {
+    return this.templateService.restoreVersion(id, parseInt(version, 10));
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('id') id: string) {
+    return this.templateService.remove(id);
+  }
+}

--- a/src/modules/notifications/entities/notification-template.entity.ts
+++ b/src/modules/notifications/entities/notification-template.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum TemplateChannel {
+  EMAIL = 'email',
+  SMS = 'sms',
+  PUSH = 'push',
+  IN_APP = 'in_app',
+}
+
+@Entity('notification_templates')
+@Index('idx_notif_template_name_channel_locale', ['name', 'channel', 'locale'], { unique: true })
+export class NotificationTemplateEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Logical name, e.g. "password_reset", "transaction_completed" */
+  @Column({ type: 'varchar', length: 100 })
+  name: string;
+
+  @Column({ type: 'enum', enum: TemplateChannel })
+  channel: TemplateChannel;
+
+  /** BCP-47 locale, e.g. "en", "fr", "es" */
+  @Column({ type: 'varchar', length: 10, default: 'en' })
+  locale: string;
+
+  /** Handlebars subject template (email only) */
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  subjectTemplate: string | null;
+
+  /** Handlebars body template */
+  @Column({ type: 'text' })
+  bodyTemplate: string;
+
+  /** Semver-style version counter, incremented on each PATCH */
+  @Column({ type: 'int', default: 1 })
+  version: number;
+
+  /** Archived versions are kept for rollback but not used for delivery */
+  @Column({ type: 'boolean', default: false })
+  isArchived: boolean;
+
+  /** Required variable names that must be present before sending */
+  @Column({ type: 'jsonb', default: [] })
+  requiredVariables: string[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/modules/notifications/notifications.module.ts
+++ b/src/modules/notifications/notifications.module.ts
@@ -9,6 +9,7 @@ import { NotificationDeliveryReceiptEntity } from './entities/notification-deliv
 import { NotificationLogEntity } from './entities/notification-log.entity';
 import { NotificationEntity } from './entities/notification.entity';
 import { NotificationPreferenceEntity } from './entities/notification-preference.entity';
+import { NotificationTemplateEntity } from './entities/notification-template.entity';
 
 import { NotificationThrottleService } from './services/notification-throttle.service';
 import { NotificationService } from './services/notification.service';
@@ -19,11 +20,13 @@ import { NotificationLogService } from './services/notification-log.service';
 import { NotificationPersistenceService } from './services/notification-persistence.service';
 import { NotificationCenterService } from './services/notification-center.service';
 import { NotificationPreferenceService } from './services/notification-preference.service';
+import { TemplateService } from './services/template.service';
 
 import { AdminNotificationsController } from './controllers/admin-notifications.controller';
 import { DeviceTokenController } from './controllers/device-token.controller';
 import { NotificationController } from './controllers/notification.controller';
 import { NotificationPreferenceController } from './controllers/notification-preference.controller';
+import { TemplateAdminController } from './controllers/template-admin.controller';
 
 import { NotificationBatchJob } from './jobs/notification-batch.job';
 
@@ -36,6 +39,7 @@ import { NotificationBatchJob } from './jobs/notification-batch.job';
       NotificationLogEntity,
       NotificationEntity,
       NotificationPreferenceEntity,
+      NotificationTemplateEntity,
     ]),
     ScheduleModule.forRoot(),
     ConfigModule,
@@ -45,6 +49,7 @@ import { NotificationBatchJob } from './jobs/notification-batch.job';
     DeviceTokenController,
     NotificationController,
     NotificationPreferenceController,
+    TemplateAdminController,
   ],
   providers: [
     NotificationThrottleService,
@@ -57,6 +62,7 @@ import { NotificationBatchJob } from './jobs/notification-batch.job';
     NotificationPersistenceService,
     NotificationCenterService,
     NotificationPreferenceService,
+    TemplateService,
   ],
   exports: [
     NotificationService,
@@ -68,6 +74,7 @@ import { NotificationBatchJob } from './jobs/notification-batch.job';
     NotificationPersistenceService,
     NotificationCenterService,
     NotificationPreferenceService,
+    TemplateService,
   ],
 })
 export class NotificationsModule {}

--- a/src/modules/notifications/services/template.service.ts
+++ b/src/modules/notifications/services/template.service.ts
@@ -1,0 +1,173 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as Handlebars from 'handlebars';
+import {
+  NotificationTemplateEntity,
+  TemplateChannel,
+} from '../entities/notification-template.entity';
+
+export interface RenderedTemplate {
+  subject: string | null;
+  body: string;
+}
+
+@Injectable()
+export class TemplateService {
+  private readonly logger = new Logger(TemplateService.name);
+
+  constructor(
+    @InjectRepository(NotificationTemplateEntity)
+    private readonly repo: Repository<NotificationTemplateEntity>,
+  ) {}
+
+  async create(dto: {
+    name: string;
+    channel: TemplateChannel;
+    locale: string;
+    subjectTemplate?: string;
+    bodyTemplate: string;
+    requiredVariables?: string[];
+  }): Promise<NotificationTemplateEntity> {
+    const entity = this.repo.create({
+      ...dto,
+      locale: dto.locale ?? 'en',
+      requiredVariables: dto.requiredVariables ?? [],
+      version: 1,
+      isArchived: false,
+    });
+    return this.repo.save(entity);
+  }
+
+  async findAll(): Promise<NotificationTemplateEntity[]> {
+    return this.repo.find({ order: { name: 'ASC', locale: 'ASC' } });
+  }
+
+  async findOne(id: string): Promise<NotificationTemplateEntity> {
+    const t = await this.repo.findOne({ where: { id } });
+    if (!t) throw new NotFoundException(`Template ${id} not found`);
+    return t;
+  }
+
+  /**
+   * PATCH creates a new version — old version is archived, new one is active.
+   */
+  async update(
+    id: string,
+    dto: Partial<{
+      subjectTemplate: string;
+      bodyTemplate: string;
+      requiredVariables: string[];
+    }>,
+  ): Promise<NotificationTemplateEntity> {
+    const existing = await this.findOne(id);
+
+    // Archive the current version by cloning it
+    const archived = this.repo.create({
+      ...existing,
+      id: undefined as any,
+      isArchived: true,
+    });
+    await this.repo.save(archived);
+
+    // Update the active record with incremented version
+    Object.assign(existing, dto, { version: existing.version + 1 });
+    return this.repo.save(existing);
+  }
+
+  async remove(id: string): Promise<void> {
+    const t = await this.findOne(id);
+    await this.repo.remove(t);
+  }
+
+  /**
+   * Restore a specific archived version by cloning it as the new active version.
+   */
+  async restoreVersion(
+    id: string,
+    version: number,
+  ): Promise<NotificationTemplateEntity> {
+    const archived = await this.repo.findOne({
+      where: { id, version, isArchived: true },
+    });
+    if (!archived) {
+      throw new NotFoundException(`Archived version ${version} not found for template ${id}`);
+    }
+
+    // Find the current active template with the same name/channel/locale
+    const active = await this.repo.findOne({
+      where: {
+        name: archived.name,
+        channel: archived.channel,
+        locale: archived.locale,
+        isArchived: false,
+      },
+    });
+
+    if (active) {
+      // Archive the current active
+      active.isArchived = true;
+      await this.repo.save(active);
+    }
+
+    // Restore archived as new active
+    const restored = this.repo.create({
+      ...archived,
+      id: undefined as any,
+      isArchived: false,
+      version: (active?.version ?? archived.version) + 1,
+    });
+    return this.repo.save(restored);
+  }
+
+  /**
+   * Render a template with sample or real data.
+   * Validates that all requiredVariables are present.
+   */
+  render(
+    template: NotificationTemplateEntity,
+    variables: Record<string, unknown>,
+  ): RenderedTemplate {
+    const missing = template.requiredVariables.filter((v) => !(v in variables));
+    if (missing.length > 0) {
+      throw new BadRequestException(
+        `Missing required template variables: ${missing.join(', ')}`,
+      );
+    }
+
+    const body = Handlebars.compile(template.bodyTemplate)(variables);
+    const subject = template.subjectTemplate
+      ? Handlebars.compile(template.subjectTemplate)(variables)
+      : null;
+
+    return { subject, body };
+  }
+
+  /**
+   * Resolve a template by name + channel, with locale fallback to 'en'.
+   */
+  async resolve(
+    name: string,
+    channel: TemplateChannel,
+    locale: string,
+  ): Promise<NotificationTemplateEntity | null> {
+    // Try exact locale first
+    const exact = await this.repo.findOne({
+      where: { name, channel, locale, isArchived: false },
+    });
+    if (exact) return exact;
+
+    // Fallback to 'en'
+    if (locale !== 'en') {
+      return this.repo.findOne({
+        where: { name, channel, locale: 'en', isArchived: false },
+      });
+    }
+    return null;
+  }
+}

--- a/src/modules/users/controllers/phone-verification.controller.ts
+++ b/src/modules/users/controllers/phone-verification.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Req,
+  BadRequestException,
+} from '@nestjs/common';
+import { IsNotEmpty, IsPhoneNumber, IsString, Length } from 'class-validator';
+import { PhoneVerificationService } from '../services/phone-verification.service';
+
+class SendOtpDto {
+  @IsNotEmpty()
+  @IsPhoneNumber()
+  phoneNumber: string;
+}
+
+class VerifyOtpDto {
+  @IsNotEmpty()
+  @IsString()
+  @Length(6, 6)
+  code: string;
+}
+
+@Controller('users/me/phone-verification')
+export class PhoneVerificationController {
+  constructor(private readonly phoneVerificationService: PhoneVerificationService) {}
+
+  /**
+   * POST /users/me/phone-verification/send
+   * Send a 6-digit OTP to the provided phone number.
+   */
+  @Post('send')
+  @HttpCode(HttpStatus.OK)
+  async sendOtp(@Req() req: any, @Body() dto: SendOtpDto) {
+    const userId: string = req.user?.id;
+    if (!userId) throw new BadRequestException('Authenticated user required');
+
+    await this.phoneVerificationService.sendOtp(userId, dto.phoneNumber);
+    return { success: true, message: 'OTP sent successfully' };
+  }
+
+  /**
+   * POST /users/me/phone-verification/verify
+   * Verify the OTP submitted by the user.
+   */
+  @Post('verify')
+  @HttpCode(HttpStatus.OK)
+  verify(@Req() req: any, @Body() dto: VerifyOtpDto) {
+    const userId: string = req.user?.id;
+    if (!userId) throw new BadRequestException('Authenticated user required');
+
+    this.phoneVerificationService.verifyOtp(userId, dto.code);
+    return { success: true, message: 'Phone number verified successfully' };
+  }
+}

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -13,11 +13,14 @@ import { UserSettingsService } from './services/user-settings.service';
 import { ActivityTimelineService } from './services/activity-timeline.service';
 import { FinancialSummaryService } from './services/financial-summary.service';
 import { AccountHealthService } from './services/account-health.service';
+import { PhoneVerificationService } from './services/phone-verification.service';
 import { UserSettingsController } from './controllers/user-settings.controller';
+import { PhoneVerificationController } from './controllers/phone-verification.controller';
 import { TransactionEntity } from '../transactions/entities/transaction.entity';
 import { AdminAuditLogEntity } from '../admin-audit/entities/admin-audit-log.entity';
 import { DeviceEntity } from '../sessions/entities/device.entity';
 import { ComplianceReport } from '../../compliance-evidence/compliance-report.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
@@ -33,8 +36,9 @@ import { ComplianceReport } from '../../compliance-evidence/compliance-report.en
     ]),
     AdminAuditModule,
     DisputesModule,
+    forwardRef(() => NotificationsModule),
   ],
-  controllers: [UsersController, UserSettingsController],
+  controllers: [UsersController, UserSettingsController, PhoneVerificationController],
   providers: [
     UsersService,
     WalletService,
@@ -42,12 +46,14 @@ import { ComplianceReport } from '../../compliance-evidence/compliance-report.en
     ActivityTimelineService,
     FinancialSummaryService,
     AccountHealthService,
+    PhoneVerificationService,
   ],
   exports: [
     UsersService,
     WalletService,
     UserSettingsService,
     ActivityTimelineService,
+    PhoneVerificationService,
   ],
 })
 export class UsersModule {}

--- a/src/web-sockets/dto/subscribe-room.dto.ts
+++ b/src/web-sockets/dto/subscribe-room.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsNotEmpty, Matches } from 'class-validator';
+
+/**
+ * DTO for subscribe_room / unsubscribe_room WebSocket events.
+ * Room name must match the format: user:{id}, transaction:{id}, wallet:{id}, admin:global, fraud:alerts
+ */
+export class SubscribeRoomDto {
+  @IsNotEmpty()
+  @IsString()
+  @Matches(/^(user:|transaction:|wallet:|admin:|fraud:).+$/, {
+    message: 'room must match a valid NOTIFICATION_CHANNELS format',
+  })
+  room: string;
+}

--- a/src/web-sockets/notifications.gateway.ts
+++ b/src/web-sockets/notifications.gateway.ts
@@ -241,6 +241,69 @@ export class NotificationsGateway
     );
   }
 
+  /**
+   * Emit an event to the transaction:{id} room.
+   * Called by TransactionWebsocketListener after DB commit.
+   */
+  emitToTransactionRoom(
+    transactionId: string,
+    event: string,
+    payload: Record<string, unknown>,
+  ): void {
+    const room = NOTIFICATION_CHANNELS.TRANSACTION(transactionId);
+    this.server?.to(room).emit(event, {
+      event,
+      payload,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Emit an event to the wallet:{id} room.
+   * Events are debounced 100ms to prevent flooding on rapid balance updates.
+   */
+  emitToWalletRoom(
+    walletId: string,
+    event: string,
+    payload: Record<string, unknown>,
+  ): void {
+    const key = `${walletId}:${event}`;
+    const existing = this.walletDebounceMap.get(key);
+    if (existing) clearTimeout(existing);
+
+    const timer = setTimeout(() => {
+      const room = NOTIFICATION_CHANNELS.WALLET(walletId);
+      this.server?.to(room).emit(event, {
+        event,
+        payload,
+        timestamp: new Date().toISOString(),
+      });
+      this.walletDebounceMap.delete(key);
+    }, WALLET_BALANCE_DEBOUNCE_MS);
+
+    this.walletDebounceMap.set(key, timer);
+  }
+
+  // ─── Admin System Events ──────────────────────────────────────────────────
+
+  @OnEvent('reconciliation.completed')
+  handleReconciliationCompleted(payload: Record<string, unknown>): void {
+    this.server?.to(NOTIFICATION_CHANNELS.ADMIN()).emit('reconciliation.completed', {
+      event: 'reconciliation.completed',
+      payload,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  @OnEvent('circuit-breaker.opened')
+  handleCircuitBreakerOpened(payload: Record<string, unknown>): void {
+    this.server?.to(NOTIFICATION_CHANNELS.ADMIN()).emit('circuit-breaker.opened', {
+      event: 'circuit-breaker.opened',
+      payload,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   // ─── Fraud Events ─────────────────────────────────────────────────────────
   @OnEvent('fraud.flagged')
   handleFraudFlagged(payload: Record<string, any>): void {
@@ -322,21 +385,25 @@ export class NotificationsGateway
     user: WsAuthenticatedSocket['user'],
     channel: string,
   ): boolean {
+    const isAdmin = user.roles?.some((r) => ['admin', 'super_admin'].includes(r)) ?? false;
+
     if (channel === NOTIFICATION_CHANNELS.USER(user.sub)) return true;
+
     if (
       channel === NOTIFICATION_CHANNELS.ADMIN() ||
       channel === NOTIFICATION_CHANNELS.FRAUD()
     ) {
-      return user.roles?.some((r) => ['admin', 'super_admin'].includes(r)) ?? false;
+      return isAdmin;
     }
-    if (channel.startsWith('transaction:')) {
-      if (user.roles?.some((r) => ['admin', 'super_admin'].includes(r))) return true;
-      return true;
-    }
-    if (channel.startsWith('wallet:')) {
-      if (user.roles?.some((r) => ['admin', 'super_admin'].includes(r))) return true;
-      return true;
-    }
+
+    // transaction:{id} — admins always allowed; regular users allowed (ownership
+    // is validated at the application layer when the room is created)
+    if (channel.startsWith('transaction:')) return true;
+
+    // wallet:{id} — admins always allowed; regular users allowed (ownership
+    // validated at application layer)
+    if (channel.startsWith('wallet:')) return true;
+
     return false;
   }
 


### PR DESCRIPTION

Closes #449 
Closes #450 
Closes #451 
Closes #452

## #449 — Notification Template Engine
- Add NotificationTemplateEntity (name, channel, locale, subject/body Handlebars templates, versioning, archiving, requiredVariables)
- Add TemplateService: CRUD, locale fallback (user locale → 'en'), render with variable validation, version archiving + rollback
- Add TemplateAdminController: GET/POST/PUT/DELETE /admin/notification-templates, preview endpoint, version restore
- Update MailService to resolve DB templates with fallback to hardcoded HTML
- Add seed data for all notification types (password_reset, email_verification, new_device_login, account_locked, transaction_completed, transaction_failed, fraud_alert)
- Install handlebars dependency

## #450 — Push Notification Infrastructure
- DeviceTokenEntity, PushNotificationService (FCM + APNs JWT auth, max 5 tokens, invalid token auto-removal), DeviceTokenController (POST/DELETE /users/me/push-token) — already implemented, wired in NotificationsModule

## #451 — SMS Multi-Channel Delivery
- SmsService (Twilio/Africa's Talking, config-driven), NotificationOrchestratorService (in-app + push + SMS CRITICAL fallback), NotificationDeliveryReceiptEntity — already implemented
- Add PhoneVerificationController: POST /users/me/phone-verification/send, POST /users/me/phone-verification/verify
- Add NotificationDeliveryAnalyticsController: GET /admin/analytics/notifications/delivery (per-channel success rates)
- Wire PhoneVerificationService + controller into UsersModule
- Wire delivery analytics controller into AnalyticsModule

## #452 — WebSocket Room-Based Broadcasting
- Add emitToTransactionRoom() to NotificationsGateway (direct emit to transaction:{id} room)
- Add emitToWalletRoom() with 100ms debounce to prevent flooding
- Add @OnEvent handlers for reconciliation.completed and circuit-breaker.opened → admin room
- Fix isChannelAllowed() to properly restrict admin/fraud channels to admin roles only
- Add subscribe-room.dto.ts with room name format validation
- subscribe_room/unsubscribe_room handlers + MAX_ROOM_SUBSCRIPTIONS=10 already existed