### PR TITLE
fix: replay cached idempotency responses

### DIFF
--- a/src/idempotency/idempotency.interceptor.ts
+++ b/src/idempotency/idempotency.interceptor.ts
@@ -5,34 +5,53 @@ import {
   CallHandler,
 } from '@nestjs/common';
 import { Observable, of } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 import { IdempotencyService } from './idempotency.service';
+
+interface IdempotencyResponsePayload {
+  statusCode: number;
+  body: unknown;
+}
+
+interface IdempotencyRequest {
+  idempotencyKey?: string;
+  requestHash?: string;
+  idempotencyResponse?: IdempotencyResponsePayload;
+}
+
+interface IdempotencyHttpResponse {
+  statusCode: number;
+  status(code: number): IdempotencyHttpResponse;
+}
 
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
   constructor(private idempotencyService: IdempotencyService) {}
 
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    const request = context.switchToHttp().getRequest();
-    const response = context.switchToHttp().getResponse();
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const http = context.switchToHttp();
+    const request = http.getRequest<IdempotencyRequest>();
+    const response = http.getResponse<IdempotencyHttpResponse>();
 
     // Return cached response immediately if it exists
     if (request.idempotencyResponse) {
       response.status(request.idempotencyResponse.statusCode);
-      return of(request.idempotencyResponse.body);
+      return of<unknown>(request.idempotencyResponse.body);
     }
 
     return next.handle().pipe(
-      tap(async (data) => {
-        // Cache response after successful commit (post-response)
-        if (request.idempotencyKey) {
+      mergeMap(async (data: unknown): Promise<unknown> => {
+        const requestHash = request.requestHash;
+
+        if (request.idempotencyKey && requestHash) {
           await this.idempotencyService.store(
             request.idempotencyKey,
-            request.requestHash,
+            requestHash,
             data,
             response.statusCode,
           );
         }
+        return data;
       }),
     );
   }

--- a/src/idempotency/idempotency.spec.ts
+++ b/src/idempotency/idempotency.spec.ts
@@ -1,0 +1,156 @@
+import { firstValueFrom, of } from 'rxjs';
+import { ExecutionContext, CallHandler } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IdempotencyGuard } from './idempotency.guard';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+import { IdempotencyService } from './idempotency.service';
+
+interface MockRequest {
+  headers: Record<string, string>;
+  method: string;
+  url: string;
+  body: {
+    amount: number;
+    currency: string;
+  };
+  idempotencyKey?: string;
+  requestHash?: string;
+  idempotencyResponse?: {
+    statusCode: number;
+    body: {
+      paymentId: string;
+    };
+  };
+}
+
+interface MockResponse {
+  statusCode: number;
+  status: jest.MockedFunction<(code: number) => MockResponse>;
+}
+
+describe('Idempotency replay flow', () => {
+  const idempotencyKey = '1234567890abcdef';
+  let request: MockRequest;
+  let response: MockResponse;
+  let context: ExecutionContext;
+
+  beforeEach(() => {
+    request = {
+      headers: {
+        'idempotency-key': idempotencyKey,
+      },
+      method: 'POST',
+      url: '/api/v1/payments',
+      body: {
+        amount: 250,
+        currency: 'USD',
+      },
+    };
+
+    response = {
+      statusCode: 201,
+      status: jest.fn((code: number) => {
+        response.statusCode = code;
+        return response;
+      }),
+    };
+
+    context = {
+      getHandler: jest.fn(),
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => response,
+      }),
+    } as unknown as ExecutionContext;
+  });
+
+  it('hydrates the cached response on a duplicate key', async () => {
+    const existingRecord = {
+      key: idempotencyKey,
+      requestHash: 'request-hash',
+      response: {
+        paymentId: 'pay_123',
+      },
+      statusCode: 202,
+    };
+
+    const reflector = {
+      get: jest.fn().mockReturnValue(true),
+    } as unknown as Reflector;
+
+    const idempotencyService = {
+      hashRequest: jest.fn().mockReturnValue('request-hash'),
+      findByKey: jest.fn().mockResolvedValue(existingRecord),
+    } as unknown as IdempotencyService;
+
+    const guard = new IdempotencyGuard(reflector, idempotencyService);
+
+    await guard.canActivate(context);
+
+    expect(request.idempotencyResponse).toEqual({
+      statusCode: 202,
+      body: existingRecord.response,
+    });
+    expect(request.idempotencyKey).toBe(idempotencyKey);
+    expect(request.requestHash).toBe('request-hash');
+  });
+
+  it('replays a cached response without calling the handler again', async () => {
+    request.idempotencyResponse = {
+      statusCode: 202,
+      body: {
+        paymentId: 'pay_123',
+      },
+    };
+
+    const idempotencyService = {
+      store: jest.fn(),
+    } as unknown as IdempotencyService;
+
+    const interceptor = new IdempotencyInterceptor(idempotencyService);
+    const next: CallHandler = {
+      handle: jest.fn(),
+    } as unknown as CallHandler;
+
+    await expect(
+      firstValueFrom(interceptor.intercept(context, next)),
+    ).resolves.toEqual({
+      paymentId: 'pay_123',
+    });
+
+    expect(response.status.mock.calls).toEqual([[202]]);
+    expect((next.handle as jest.Mock).mock.calls).toHaveLength(0);
+    expect((idempotencyService.store as jest.Mock).mock.calls).toHaveLength(0);
+  });
+
+  it('stores the response after a successful new request', async () => {
+    request.idempotencyKey = idempotencyKey;
+    request.requestHash = 'request-hash';
+
+    const idempotencyService = {
+      store: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IdempotencyService;
+
+    const interceptor = new IdempotencyInterceptor(idempotencyService);
+    const next: CallHandler = {
+      handle: jest.fn().mockReturnValue(of({ paymentId: 'pay_456' })),
+    } as unknown as CallHandler;
+
+    await expect(
+      firstValueFrom(interceptor.intercept(context, next)),
+    ).resolves.toEqual({
+      paymentId: 'pay_456',
+    });
+
+    expect((idempotencyService.store as jest.Mock).mock.calls).toEqual([
+      [
+        idempotencyKey,
+        'request-hash',
+        {
+          paymentId: 'pay_456',
+        },
+        201,
+      ],
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #566

## Summary
- short-circuit duplicate idempotency requests with the cached response
- persist successful responses after the handler completes
- add a focused spec covering guard hydration, replay, and response storage

## Validation
- `npm test -- --runInBand --watchman=false src/idempotency/idempotency.spec.ts`
- `npx --no-install eslint src/idempotency/idempotency.interceptor.ts src/idempotency/idempotency.spec.ts`
- `npm run build