### PR TITLE
docs: add contributor and architecture guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for helping improve `NexaFx-js`.
+
+## Local setup
+
+1. Copy the environment template and fill in the required values:
+   ```bash
+   cp .env.example .env
+   ```
+2. Start the backing services with Docker Compose if you use local containers for PostgreSQL and Redis.
+3. Install dependencies and run the seed script when your environment needs sample data:
+   ```bash
+   npm ci
+   npm run seed
+   ```
+
+## Branching strategy
+
+- Use short-lived feature branches such as `fix/issue-123-short-description`.
+- Keep each branch scoped to a single issue or small, related change set.
+- Open pull requests from your fork into `Nexacore-Org/NexaFx-js`.
+
+## Commit and PR format
+
+- Prefer conventional commits such as `fix:`, `feat:`, or `chore:`.
+- Reference the issue number in the PR description with `Closes #123`.
+- Keep PR titles concise and action-oriented.
+
+## Code style
+
+- ESLint and Prettier are already configured in the repository.
+- Use the existing TypeScript patterns in the codebase: single quotes, 2-space indentation, and small focused modules.
+- Avoid unrelated refactors when you are fixing a specific issue.
+
+## Testing requirements
+
+- Run the relevant unit tests before opening a PR:
+  ```bash
+  npm test
+  ```
+- Run coverage checks for larger changes:
+  ```bash
+  npm run test:cov
+  ```
+- Run the build to verify the app still compiles:
+  ```bash
+  npm run build
+  ```
+- The repository enforces coverage thresholds in `package.json` for the highest-risk modules.
+
+## Pull request checklist
+
+- [ ] Change is scoped to the issue.
+- [ ] Tests pass locally.
+- [ ] Build passes locally.
+- [ ] Coverage stays above the configured thresholds.
+- [ ] README or docs are updated when behavior changes.
+- [ ] PR description includes a short summary and testing notes.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@
 
 [Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
 
+## Documentation
+
+- [Contributing guide](./CONTRIBUTING.md)
+- [Architecture overview](./docs/architecture.md)
+
 ## Project setup
 
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,64 @@
+# Architecture
+
+This repository is a NestJS application organized around a small set of focused modules:
+
+- `ConfigModule` validates and structures runtime configuration.
+- `IdempotencyModule` deduplicates replayable requests and stores cached responses.
+- `WalletsModule` manages in-memory balance updates.
+- `ActivityFeedModule` stores and serves audit-style activity records.
+
+## Module dependency graph
+
+```mermaid
+flowchart LR
+  AppModule["AppModule"] --> ConfigModule["ConfigModule"]
+  AppModule --> TypeOrmModule["TypeOrmModule"]
+  AppModule --> BullModule["BullModule"]
+  AppModule --> IdempotencyModule["IdempotencyModule"]
+  AppModule --> WalletsModule["WalletsModule"]
+  WalletsModule --> ActivityFeedModule["ActivityFeedModule"]
+  IdempotencyModule --> TypeOrmModule
+  IdempotencyModule --> ScheduleModule["ScheduleModule"]
+  ActivityFeedModule --> TypeOrmModule
+```
+
+## Authentication flow
+
+The repository currently does not ship a full auth module, but the expected request flow is:
+
+```mermaid
+flowchart LR
+  Client["Client"] --> Api["API request"]
+  Api --> JwtGuard["Auth guard / JWT validation"]
+  JwtGuard --> UserContext["Authenticated user context"]
+  UserContext --> Controllers["Controllers"]
+  Controllers --> Services["Services"]
+```
+
+## Transaction lifecycle
+
+Wallet balance changes and related activity events follow the same general lifecycle:
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant WalletsController
+  participant WalletsService
+  participant ActivityFeedService
+  participant Database
+
+  Client->>WalletsController: Adjust balance request
+  WalletsController->>WalletsService: adjustBalance(...)
+  WalletsService->>Database: Update balance state
+  WalletsService->>ActivityFeedService: recordActivity(...)
+  ActivityFeedService->>Database: Persist activity event
+  WalletsService-->>Client: Updated balance
+```
+
+## Key design decisions
+
+- **Idempotency first**: replayable requests are cached so duplicate submissions can reuse a safe response.
+- **Event-driven hooks**: balance changes emit activity records so the feed stays in sync with business events.
+- **Structured feed items**: the activity feed returns consistent fields (`timestamp`, `type`, `description`, `ipAddress`, `deviceInfo`, `securityEvent`) for UI rendering.
+- **Configuration validation**: environment values are validated at startup to fail fast on bad deployment settings.
+- **Modular boundaries**: each domain area stays in its own Nest module to keep growth manageable.


### PR DESCRIPTION
Closes #648

## Summary
- add a contributor guide covering setup, branching, style, tests, and PR expectations
- add an architecture doc with Mermaid diagrams for modules, auth, and transaction flow
- link both documents from the README

## Testing
- Documentation-only change; no application runtime changes
- Verified the branch diff and README links locally