### PR TITLE
fix: enable TypeScript strict mode and add composite DB indexes

### DIFF
--- a/docs/database-indexes.md
+++ b/docs/database-indexes.md
@@ -1,0 +1,31 @@
+# Database Index Strategy
+
+## Transaction
+
+| Index | Columns | Rationale |
+|-------|---------|-----------|
+| Composite | `(senderId, createdAt)` | Transaction history per user ordered by date |
+| Composite | `(status, createdAt)` | Job processor queue — pending transactions by age |
+| Composite | `(currency, createdAt)` | AML structuring window queries by currency |
+| Single | `senderId` | Lookup all transactions sent by a user |
+| Single | `receiverId` | Lookup all transactions received by a user |
+| Unique | `reference` | Idempotency — prevent duplicate transactions |
+
+## WalletBalance
+
+| Index | Columns | Rationale |
+|-------|---------|-----------|
+| Unique composite | `(accountId, currency)` | Every balance lookup — one row per account+currency |
+
+## AuditLog
+
+| Index | Columns | Rationale |
+|-------|---------|-----------|
+| Composite | `(userId, createdAt)` | Audit trail per user ordered by time |
+| Composite | `(entityType, entityId)` | Lookup all audit events for a specific entity |
+
+## IdempotencyKey
+
+| Index | Columns | Rationale |
+|-------|---------|-----------|
+| Single | `expiresAt` | Cleanup job — find and delete expired keys |

--- a/src/transactions/transaction.entity.ts
+++ b/src/transactions/transaction.entity.ts
@@ -14,6 +14,9 @@ export enum TransactionStatus {
 }
 
 @Entity('transactions')
+@Index(['senderId', 'createdAt'])
+@Index(['status', 'createdAt'])
+@Index(['currency', 'createdAt'])
 @Index(['senderId'])
 @Index(['receiverId'])
 @Index(['createdAt'])
@@ -54,17 +57,17 @@ export class Transaction {
   createdAt: Date;
 
   @Column({ type: 'timestamp', nullable: true })
-  completedAt: Date;
+  completedAt: Date | null;
 
   @Column({ type: 'timestamp', nullable: true })
-  reversedAt: Date;
+  reversedAt: Date | null;
 
   @Column({ type: 'uuid', nullable: true })
-  reversedBy: string;
+  reversedBy: string | null;
 
   @Column({ type: 'text', nullable: true })
-  reversalReason: string;
+  reversalReason: string | null;
 
   @Column({ type: 'uuid', nullable: true })
-  reversalTransactionId: string;
+  reversalTransactionId: string | null;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,10 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-    "strictNullChecks": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   }
 }


### PR DESCRIPTION
## Summary

- tsconfig.json: enabled strict, noUncheckedIndexedAccess, and noImplicitReturns. Removed the loose noImplicitAny: false and strictBindCallApply: false overrides.
- Transaction entity: added composite indexes (senderId+createdAt), (status+createdAt), (currency+createdAt) for financial query patterns.
- Added docs/database-indexes.md documenting each index and the query it serves.

## Changes

- tsconfig.json
- src/transactions/transaction.entity.ts
- docs/database-indexes.md

closes #686
closes #687