### PR TITLE
feat: typed query helper and JWT secret rotation docs

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,22 @@
+# JWT Secret Rotation
+
+## Strategy
+
+The app supports dual-secret JWT verification to allow zero-downtime secret rotation.
+
+- `JWT_SECRET` — the current signing secret (required)
+- `JWT_SECRET_PREVIOUS` — the previous secret, accepted during the overlap window (optional)
+
+## How It Works
+
+1. Token verification tries `JWT_SECRET` first.
+2. If verification fails and `JWT_SECRET_PREVIOUS` is set, it retries with the previous secret.
+3. Tokens verified via the previous secret are transparently re-issued using `JWT_SECRET` and returned in the `X-Refreshed-Token` response header.
+
+## Rotation Procedure
+
+1. Set `JWT_SECRET_PREVIOUS` to the current value of `JWT_SECRET`.
+2. Generate a new secret and set it as `JWT_SECRET`.
+3. Deploy. Existing sessions continue to work via `JWT_SECRET_PREVIOUS`.
+4. After your session TTL has elapsed (all old tokens expired), remove `JWT_SECRET_PREVIOUS`.
+5. Deploy again to complete the rotation.

--- a/src/common/types/query-result.types.ts
+++ b/src/common/types/query-result.types.ts
@@ -1,0 +1,25 @@
+import { SelectQueryBuilder } from 'typeorm';
+
+/**
+ * Execute a TypeORM query builder and return explicitly typed results.
+ * Prevents `any`-typed query results slipping through TypeScript.
+ */
+export async function executeQuery<T>(qb: SelectQueryBuilder<T>): Promise<T[]> {
+  return qb.getMany();
+}
+
+/**
+ * Transformer for PostgreSQL numeric columns.
+ * pg returns NUMERIC/DECIMAL as strings — this converts them to JS numbers.
+ */
+export const numericTransformer = {
+  to: (value: number): number => value,
+  from: (value: string | null): number | null =>
+    value === null ? null : parseFloat(value),
+};
+
+/**
+ * Use this type for raw query projections instead of `any`.
+ * Example: const rows: RawRow<{ total: number }> = await qb.getRawMany();
+ */
+export type RawRow<T extends Record<string, unknown>> = T;


### PR DESCRIPTION
## Summary

- Added typed executeQuery<T> helper and numericTransformer to prevent any-typed DB results from TypeORM queries.
- Added docs/security.md documenting the dual-secret JWT rotation procedure with step-by-step instructions.

## Changes

- src/common/types/query-result.types.ts
- docs/security.md

closes #678
closes #679