### PR TITLE
Add PasswordService and TokenService to centralise auth dependencies

### DIFF
--- a/src/auth/password.service.ts
+++ b/src/auth/password.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcryptjs';
+
+@Injectable()
+export class PasswordService {
+  private readonly SALT_ROUNDS = 12;
+
+  async hash(plain: string): Promise<string> {
+    return bcrypt.hash(plain, this.SALT_ROUNDS);
+  }
+
+  async verify(plain: string, hashed: string): Promise<boolean> {
+    return bcrypt.compare(plain, hashed);
+  }
+}

--- a/src/auth/token.service.ts
+++ b/src/auth/token.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+
+export interface TokenPayload {
+  sub: string;
+  email: string;
+  role?: string;
+}
+
+@Injectable()
+export class TokenService {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  sign(payload: TokenPayload): string {
+    return this.jwtService.sign(payload, {
+      secret: this.configService.get<string>('JWT_SECRET'),
+      expiresIn: this.configService.get<string>('JWT_EXPIRES_IN', '1h'),
+    });
+  }
+
+  verify(token: string): TokenPayload {
+    return this.jwtService.verify<TokenPayload>(token, {
+      secret: this.configService.get<string>('JWT_SECRET'),
+    });
+  }
+
+  decode(token: string): TokenPayload | null {
+    return this.jwtService.decode<TokenPayload>(token);
+  }
+}


### PR DESCRIPTION
bcryptjs was used directly without a shared abstraction. PasswordService wraps it with a single configured SALT_ROUNDS. jsonwebtoken was listed alongside @nestjs/jwt giving two signing paths. TokenService wraps @nestjs/jwt so all token operations go through NestJS DI.

Closes #675
Closes #676