### PR TITLE
Add queue monitor endpoint and blockchain service

### DIFF
--- a/src/blockchain/blockchain.service.ts
+++ b/src/blockchain/blockchain.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+
+@Injectable()
+export class BlockchainService {
+  private readonly logger = new Logger(BlockchainService.name);
+  private readonly rpcUrl: string;
+  private readonly requiredConfirmations: number;
+
+  constructor(private readonly config: ConfigService) {
+    this.rpcUrl = this.config.get<string>('BLOCKCHAIN_RPC_URL', 'http://localhost:8545');
+    this.requiredConfirmations = this.config.get<number>('BLOCKCHAIN_REQUIRED_CONFIRMATIONS', 12);
+  }
+
+  private async rpc(method: string, params: unknown[]): Promise<unknown> {
+    const { data } = await axios.post(this.rpcUrl, { jsonrpc: '2.0', id: 1, method, params });
+    if (data.error) throw new Error(`RPC error: ${data.error.message}`);
+    return data.result;
+  }
+
+  async getBalance(address: string): Promise<string> {
+    const hex = await this.rpc('eth_getBalance', [address, 'latest']) as string;
+    return (BigInt(hex) / BigInt(1e18)).toString();
+  }
+
+  async watchTransaction(txHash: string): Promise<boolean> {
+    const receipt = await this.rpc('eth_getTransactionReceipt', [txHash]) as { blockNumber: string } | null;
+    if (!receipt) return false;
+    const latest = await this.rpc('eth_blockNumber', []) as string;
+    const confirmations = Number(BigInt(latest) - BigInt(receipt.blockNumber));
+    return confirmations >= this.requiredConfirmations;
+  }
+
+  validateAddress(address: string): boolean {
+    return /^0x[0-9a-fA-F]{40}$/.test(address);
+  }
+}

--- a/src/queues/queue-monitor.controller.ts
+++ b/src/queues/queue-monitor.controller.ts
@@ -1,0 +1,45 @@
+import { Controller, Get, Param, NotFoundException } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import { QUEUE_NAMES } from './queue.constants';
+
+@Controller('queues')
+export class QueueMonitorController {
+  constructor(
+    @InjectQueue(QUEUE_NAMES.EMAIL) private emailQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.NOTIFICATION) private notificationQueue: Queue,
+    @InjectQueue(QUEUE_NAMES.TRANSACTION) private transactionQueue: Queue,
+  ) {}
+
+  private queues(): Record<string, Queue> {
+    return {
+      [QUEUE_NAMES.EMAIL]: this.emailQueue,
+      [QUEUE_NAMES.NOTIFICATION]: this.notificationQueue,
+      [QUEUE_NAMES.TRANSACTION]: this.transactionQueue,
+    };
+  }
+
+  @Get()
+  async getAll() {
+    const stats: Record<string, object> = {};
+    for (const [name, queue] of Object.entries(this.queues())) {
+      const [waiting, active, completed, failed, delayed] = await Promise.all([
+        queue.getWaitingCount(),
+        queue.getActiveCount(),
+        queue.getCompletedCount(),
+        queue.getFailedCount(),
+        queue.getDelayedCount(),
+      ]);
+      stats[name] = { waiting, active, completed, failed, delayed };
+    }
+    return stats;
+  }
+
+  @Get(':name/failed')
+  async getFailed(@Param('name') name: string) {
+    const queue = this.queues()[name];
+    if (!queue) throw new NotFoundException(`Queue "${name}" not found`);
+    const jobs = await queue.getFailed(0, 49);
+    return jobs.map((j) => ({ id: j.id, name: j.name, failedReason: j.failedReason, timestamp: j.timestamp }));
+  }
+}


### PR DESCRIPTION
Queue depths, failed jobs and processing rates were invisible to operators. QueueMonitorController exposes GET /queues and GET /queues/:name/failed using existing @nestjs/bull injection. BLOCKCHAIN_RPC_URL and BLOCKCHAIN_REQUIRED_CONFIRMATIONS were defined but no module existed. BlockchainService uses axios (already in package.json) for JSON-RPC: getBalance, watchTransaction, and validateAddress.

Closes #677
Closes #611