### PR TITLE
fix(env): require WALLET_ENCRYPTION_KEY via Zod, remove duplicate runtime validation, update env example and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ REFRESH_TOKEN_EXPIRY=604800
 OTP_SECRET=your_super_secret_otp_key_must_be_at_least_32_characters_long
 OTP_EXPIRY=300
 
-# Wallet Encryption Configuration (64-character hex string)
+# Wallet Encryption Configuration (exactly 64 lowercase hex chars, generated via `openssl rand -hex 32`)
 WALLET_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
 # External Service Credentials

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,5 +1,3 @@
-import { validateWalletEncryptionKey } from './env.validation';
-
 /**
  * Configuration factory that structures validated env vars
  * into logical groups for easy access throughout the app
@@ -18,14 +16,6 @@ import { validateWalletEncryptionKey } from './env.validation';
  * - rateLimit: Rate limiting settings
  */
 export default () => {
-  // Additional runtime validation for wallet encryption key format
-  const walletKey = process.env.WALLET_ENCRYPTION_KEY || '';
-  if (walletKey && !validateWalletEncryptionKey(walletKey)) {
-    throw new Error(
-      'WALLET_ENCRYPTION_KEY must be a valid 64-character hexadecimal string',
-    );
-  }
-
   const nodeEnv = process.env.NODE_ENV || 'development';
   const port = parseInt(process.env.PORT || '3000', 10);
   const bodyLimitJson = parseInt(process.env.BODY_LIMIT_JSON || '10', 10);

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -30,6 +30,8 @@ const VALID_ENV: Record<string, string> = {
   // OTP
   OTP_SECRET: 'c'.repeat(32),
   OTP_EXPIRY: '300',
+  // Wallet Encryption Key
+  WALLET_ENCRYPTION_KEY: VALID_KEY_64,
   // Mail
   MAIL_HOST: 'smtp.example.com',
   MAIL_PORT: '587',
@@ -241,12 +243,13 @@ describe('validateEnv', () => {
     });
   });
 
-  // ── WALLET_ENCRYPTION_KEY (optional with refine) ──────────────────────────
+  // ── WALLET_ENCRYPTION_KEY (required 64-char hex string) ────────────────
 
   describe('WALLET_ENCRYPTION_KEY', () => {
-    it('passes when absent (field is optional)', () => {
-      const result = validateEnv(env({ WALLET_ENCRYPTION_KEY: undefined }));
-      expect(result.WALLET_ENCRYPTION_KEY).toBeUndefined();
+    it('fails when WALLET_ENCRYPTION_KEY is missing', () => {
+      expect(() => validateEnv(env({ WALLET_ENCRYPTION_KEY: undefined }))).toThrow(
+        'WALLET_ENCRYPTION_KEY is required',
+      );
     });
 
     it('accepts a valid 64-character lowercase hex string', () => {
@@ -263,26 +266,26 @@ describe('validateEnv', () => {
     it('fails when key is 63 characters (too short)', () => {
       expect(() =>
         validateEnv(env({ WALLET_ENCRYPTION_KEY: 'a'.repeat(63) })),
-      ).toThrow('WALLET_ENCRYPTION_KEY must be a 64-character hex string');
+      ).toThrow('WALLET_ENCRYPTION_KEY must be exactly 64 hex characters');
     });
 
     it('fails when key is 65 characters (too long)', () => {
       expect(() =>
         validateEnv(env({ WALLET_ENCRYPTION_KEY: 'a'.repeat(65) })),
-      ).toThrow('WALLET_ENCRYPTION_KEY must be a 64-character hex string');
+      ).toThrow('WALLET_ENCRYPTION_KEY must be exactly 64 hex characters');
     });
 
     it('fails when key contains non-hex characters', () => {
       const invalidKey = 'z'.repeat(64); // 'z' is not a hex char
       expect(() =>
         validateEnv(env({ WALLET_ENCRYPTION_KEY: invalidKey })),
-      ).toThrow('WALLET_ENCRYPTION_KEY must be a 64-character hex string');
+      ).toThrow('WALLET_ENCRYPTION_KEY must be a valid hex string');
     });
 
     it('fails when key is an empty string', () => {
       expect(() =>
         validateEnv(env({ WALLET_ENCRYPTION_KEY: '' })),
-      ).toThrow('WALLET_ENCRYPTION_KEY must be a 64-character hex string');
+      ).toThrow('WALLET_ENCRYPTION_KEY must be exactly 64 hex characters');
     });
   });
 

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -331,10 +331,9 @@ export const envSchema = z.object({
   // ============================================
   WALLET_ENCRYPTION_KEY: z
     .string()
-    .optional()
-    .refine((val) => !val || (hexStringRegex.test(val) && val.length === 64), {
-      message: 'WALLET_ENCRYPTION_KEY must be a 64-character hex string',
-    }),
+    .min(1, 'WALLET_ENCRYPTION_KEY is required')
+    .length(64, 'WALLET_ENCRYPTION_KEY must be exactly 64 hex characters')
+    .regex(/^[0-9a-fA-F]{64}$/, 'WALLET_ENCRYPTION_KEY must be a valid hex string'),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/idempotency/idempotency.interceptor.spec.ts
+++ b/src/idempotency/idempotency.interceptor.spec.ts
@@ -83,4 +83,66 @@ describe('IdempotencyInterceptor', () => {
       204,
     );
   });
+
+  it('awaits idempotency storage before emitting the response', async () => {
+    let resolveStore: () => void;
+    const storePromise = new Promise<void>((resolve) => {
+      resolveStore = resolve;
+    });
+
+    storeMock.mockReturnValue(storePromise);
+    const response = {
+      statusCode: 201,
+    };
+    const request = {
+      idempotencyKey: '1234567890abcdef',
+      requestHash: 'hash',
+    };
+    const handleMock = jest.fn(() => of({ ok: true }));
+    const next: Pick<CallHandler, 'handle'> = {
+      handle: handleMock,
+    };
+
+    const resultPromise = lastValueFrom(
+      interceptor.intercept(createContext(request, response), next),
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(storeMock).toHaveBeenCalled();
+    const raceResult = await Promise.race([resultPromise, Promise.resolve('pending')]);
+    expect(raceResult).toBe('pending');
+
+    resolveStore!();
+    await expect(resultPromise).resolves.toEqual({ ok: true });
+  });
+
+  it('returns the response even when storage fails', async () => {
+    const error = new Error('storage failed');
+    storeMock.mockRejectedValue(error);
+    const logSpy = jest.spyOn(interceptor['logger'], 'error');
+
+    const response = {
+      statusCode: 200,
+    };
+    const request = {
+      idempotencyKey: '1234567890abcdef',
+      requestHash: 'hash',
+    };
+    const handleMock = jest.fn(() => of({ ok: true }));
+    const next: Pick<CallHandler, 'handle'> = {
+      handle: handleMock,
+    };
+
+    await expect(
+      lastValueFrom(
+        interceptor.intercept(createContext(request, response), next),
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    expect(storeMock).toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith(
+      'Failed to persist idempotency response',
+      error,
+    );
+  });
 });

--- a/src/idempotency/idempotency.interceptor.ts
+++ b/src/idempotency/idempotency.interceptor.ts
@@ -3,9 +3,10 @@ import {
   NestInterceptor,
   ExecutionContext,
   CallHandler,
+  Logger,
 } from '@nestjs/common';
-import { Observable, of } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { Observable, of, from } from 'rxjs';
+import { switchMap, mapTo, catchError } from 'rxjs/operators';
 import { IdempotencyService } from './idempotency.service';
 
 interface IdempotencyResponsePayload {
@@ -26,6 +27,8 @@ interface IdempotencyHttpResponse {
 
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(IdempotencyInterceptor.name);
+
   constructor(private idempotencyService: IdempotencyService) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
@@ -40,18 +43,31 @@ export class IdempotencyInterceptor implements NestInterceptor {
     }
 
     return next.handle().pipe(
-      mergeMap(async (data: unknown): Promise<unknown> => {
+      switchMap((data: unknown) => {
         const requestHash = request.requestHash;
 
-        if (request.idempotencyKey && requestHash) {
-          await this.idempotencyService.store(
-            request.idempotencyKey,
-            requestHash,
-            data,
-            response.statusCode,
-          );
+        if (!request.idempotencyKey || !requestHash) {
+          return of(data);
         }
-        return data;
+
+        return from(
+          this.idempotencyService
+            .store(
+              request.idempotencyKey,
+              requestHash,
+              data,
+              response.statusCode,
+            )
+            .then(() => data),
+        ).pipe(
+          catchError((error: unknown) => {
+            this.logger.error(
+              'Failed to persist idempotency response',
+              error as Error,
+            );
+            return of(data);
+          }),
+        );
       }),
     );
   }


### PR DESCRIPTION
Closes #712

fix(env): require WALLET_ENCRYPTION_KEY via Zod, remove duplicate runtime validation, update env example and tests
fix(idempotency): await storage with switchMap, log store errors, add ordering and failure tests

Closes #713