### PR TITLE
security hardening, config pipeline, and integration test infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,8 @@ REFRESH_TOKEN_EXPIRY=604800
 OTP_SECRET=your_super_secret_otp_key_must_be_at_least_32_characters_long
 OTP_EXPIRY=300
 
-# Wallet Encryption Configuration (64-character hex string)
+# Wallet Encryption Configuration (required — exactly 64 lowercase hex chars)
+# Generate with: openssl rand -hex 32
 WALLET_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
 # External Service Credentials

--- a/jest.integration.json
+++ b/jest.integration.json
@@ -1,0 +1,14 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "src",
+  "testRegex": ".*\\.integration-spec\\.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "collectCoverageFrom": ["**/*.(t|j)s"],
+  "coverageDirectory": "../coverage-integration",
+  "testEnvironment": "node",
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/$1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "seed": "ts-node -r tsconfig-paths/register src/database/seeds/seed.ts",
     "prepare": "husky",
     "test:unit:wallet-currencies": "jest src/wallet/wallets.service.spec.ts src/wallet/wallets.controller.spec.ts src/currencies/currencies.service.spec.ts src/currencies/currencies.controller.spec.ts --runInBand",
-    "test:integration:wallet-currencies": "jest test/wallets-currencies.e2e-spec.ts --runInBand --config ./test/jest-e2e.json"
+    "test:integration:wallet-currencies": "jest test/wallets-currencies.e2e-spec.ts --runInBand --config ./test/jest-e2e.json",
+    "test:integration": "jest --config ./jest.integration.json --runInBand",
+    "check:no-wildcard-deps": "node -e \"const pkg=require('./package.json');const w=Object.entries({...pkg.dependencies,...pkg.devDependencies}).filter(([,v])=>v==='*');if(w.length){console.error('Wildcard dependencies found:',w);process.exit(1);}\""
   },
   "dependencies": {
     "@nestjs-modules/ioredis": "^2.2.1",
@@ -37,7 +39,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/jwt": "^11.0.2",
-    "@nestjs/mapped-types": "*",
+    "@nestjs/mapped-types": "^2.1.1",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.1.17",

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,5 +1,3 @@
-import { validateWalletEncryptionKey } from './env.validation';
-
 /**
  * Configuration factory that structures validated env vars
  * into logical groups for easy access throughout the app
@@ -18,16 +16,12 @@ import { validateWalletEncryptionKey } from './env.validation';
  * - rateLimit: Rate limiting settings
  */
 export default () => {
-  // Additional runtime validation for wallet encryption key format
-  const walletKey = process.env.WALLET_ENCRYPTION_KEY || '';
-  if (walletKey && !validateWalletEncryptionKey(walletKey)) {
-    throw new Error(
-      'WALLET_ENCRYPTION_KEY must be a valid 64-character hexadecimal string',
-    );
-  }
+  // WALLET_ENCRYPTION_KEY is required and validated by Zod in env.validation.ts
+  const walletKey = process.env.WALLET_ENCRYPTION_KEY!;
 
   const nodeEnv = process.env.NODE_ENV || 'development';
   const port = parseInt(process.env.PORT || '3000', 10);
+  const swaggerEnabled = process.env.SWAGGER_ENABLED === 'true';
   const bodyLimitJson = parseInt(process.env.BODY_LIMIT_JSON || '10', 10);
   const bodyLimitUrlencoded = parseInt(
     process.env.BODY_LIMIT_URLENCODED || '10',
@@ -114,6 +108,7 @@ export default () => {
     app: {
       nodeEnv,
       port,
+      swaggerEnabled,
       isProduction: nodeEnv === 'production',
       isDevelopment: nodeEnv === 'development',
       isTest: nodeEnv === 'test',

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -39,6 +39,8 @@ const VALID_ENV: Record<string, string> = {
   MAIL_SECURE: 'false',
   // Observability
   SLOW_QUERY_THRESHOLD_MS: '1000',
+  // Wallet encryption (required, 64-char hex)
+  WALLET_ENCRYPTION_KEY: VALID_KEY_64,
 };
 
 /** Return a copy of VALID_ENV with the given overrides applied. */
@@ -241,12 +243,13 @@ describe('validateEnv', () => {
     });
   });
 
-  // ── WALLET_ENCRYPTION_KEY (optional with refine) ──────────────────────────
+  // ── WALLET_ENCRYPTION_KEY (required, 64-char hex) ────────────────────────
 
   describe('WALLET_ENCRYPTION_KEY', () => {
-    it('passes when absent (field is optional)', () => {
-      const result = validateEnv(env({ WALLET_ENCRYPTION_KEY: undefined }));
-      expect(result.WALLET_ENCRYPTION_KEY).toBeUndefined();
+    it('fails when absent (field is required)', () => {
+      expect(() =>
+        validateEnv(env({ WALLET_ENCRYPTION_KEY: undefined })),
+      ).toThrow('Environment validation failed');
     });
 
     it('accepts a valid 64-character lowercase hex string', () => {

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -107,9 +107,6 @@ export const envSchema = z.object({
   // ============================================
   // Wallet Encryption Configuration
   // ============================================
-  // WALLET_ENCRYPTION_KEY: z
-  //   .string()
-  //   .length(64, "WALLET_ENCRYPTION_KEY must be exactly 64 characters (hex)"),
 
   // ============================================
   // External Service Credentials
@@ -327,12 +324,12 @@ export const envSchema = z.object({
   EXCHANGE_RATE_HOST_API_KEY: z.string().optional(),
 
   // ============================================
-  // Wallet Encryption Key (64-char hex)
+  // Wallet Encryption Key (64-char hex, required)
   // ============================================
   WALLET_ENCRYPTION_KEY: z
     .string()
-    .optional()
-    .refine((val) => !val || (hexStringRegex.test(val) && val.length === 64), {
+    .min(1, 'WALLET_ENCRYPTION_KEY is required')
+    .refine((val) => hexStringRegex.test(val) && val.length === 64, {
       message: 'WALLET_ENCRYPTION_KEY must be a 64-character hex string',
     }),
 });

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '5432', 10),
+  username: process.env.DB_USER || 'postgres',
+  password: process.env.DB_PASSWORD || 'postgres',
+  database: process.env.DB_NAME || 'nexafx_dev',
+  synchronize: false,
+  logging: process.env.NODE_ENV === 'development',
+  entities: ['src/**/*.entity.ts'],
+  migrations: ['src/database/migrations/*.ts'],
+  migrationsTableName: 'typeorm_migrations',
+});
+
+export default AppDataSource;

--- a/src/database/migrations/AlterIdempotencyKeyLength1748880000000.ts
+++ b/src/database/migrations/AlterIdempotencyKeyLength1748880000000.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterIdempotencyKeyLength1748880000000
+  implements MigrationInterface
+{
+  name = 'AlterIdempotencyKeyLength1748880000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "idempotency_keys" ALTER COLUMN "key" TYPE VARCHAR(255)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "idempotency_keys" ALTER COLUMN "key" TYPE TEXT`,
+    );
+  }
+}

--- a/src/idempotency/idempotency.entity.ts
+++ b/src/idempotency/idempotency.entity.ts
@@ -10,7 +10,7 @@ import {
 @Index(['createdAt'])
 @Index(['expiresAt'])
 export class IdempotencyKey {
-  @PrimaryColumn()
+  @PrimaryColumn({ length: 255 })
   key: string;
 
   @Column('text')

--- a/src/idempotency/idempotency.guard.spec.ts
+++ b/src/idempotency/idempotency.guard.spec.ts
@@ -4,7 +4,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { IdempotencyGuard } from './idempotency.guard';
+import { IdempotencyGuard, MIN_KEY_LENGTH, MAX_KEY_LENGTH } from './idempotency.guard';
 import { IdempotencyService } from './idempotency.service';
 import { IDEMPOTENCY_KEY } from './idempotency.decorator';
 
@@ -12,7 +12,7 @@ import { IDEMPOTENCY_KEY } from './idempotency.decorator';
 // Helpers
 // ---------------------------------------------------------------------------
 
-const VALID_KEY = 'a'.repeat(16); // exactly MIN_KEY_LENGTH
+const VALID_KEY = 'a'.repeat(MIN_KEY_LENGTH); // exactly MIN_KEY_LENGTH
 const HASH = 'abc123hash';
 
 function makeContext(overrides: {
@@ -92,6 +92,37 @@ describe('IdempotencyGuard', () => {
       await expect(guard.canActivate(ctx)).rejects.toThrow(
         'at least 16 characters',
       );
+    });
+
+    it('accepts a key of exactly 255 characters', async () => {
+      const service = makeService(null);
+      const guard = new IdempotencyGuard(makeReflector(true), service);
+      const ctx = makeContext({
+        headers: { 'idempotency-key': 'a'.repeat(MAX_KEY_LENGTH) },
+      });
+
+      await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    });
+
+    it('throws BadRequestException when key is 256 characters (exceeds MAX_KEY_LENGTH)', async () => {
+      const guard = new IdempotencyGuard(makeReflector(true), makeService());
+      const ctx = makeContext({
+        headers: { 'idempotency-key': 'a'.repeat(MAX_KEY_LENGTH + 1) },
+      });
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(BadRequestException);
+      await expect(guard.canActivate(ctx)).rejects.toThrow(
+        `must not exceed ${MAX_KEY_LENGTH} characters`,
+      );
+    });
+
+    it('throws BadRequestException when key is 1 MB (far exceeds MAX_KEY_LENGTH)', async () => {
+      const guard = new IdempotencyGuard(makeReflector(true), makeService());
+      const ctx = makeContext({
+        headers: { 'idempotency-key': 'a'.repeat(1024 * 1024) },
+      });
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(BadRequestException);
     });
 
     it('returns true and attaches key/hash to request on first (fresh) request', async () => {

--- a/src/idempotency/idempotency.guard.ts
+++ b/src/idempotency/idempotency.guard.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   CanActivate,
   ExecutionContext,
-  ConflictException,
   BadRequestException,
   UnprocessableEntityException,
 } from '@nestjs/common';
@@ -10,7 +9,8 @@ import { Reflector } from '@nestjs/core';
 import { IdempotencyService } from './idempotency.service';
 import { IDEMPOTENCY_KEY } from './idempotency.decorator';
 
-const MIN_KEY_LENGTH = 16;
+export const MIN_KEY_LENGTH = 16;
+export const MAX_KEY_LENGTH = 255;
 
 @Injectable()
 export class IdempotencyGuard implements CanActivate {
@@ -39,6 +39,11 @@ export class IdempotencyGuard implements CanActivate {
     if (idempotencyKey.length < MIN_KEY_LENGTH) {
       throw new BadRequestException(
         `Idempotency-Key must be at least ${MIN_KEY_LENGTH} characters`,
+      );
+    }
+    if (idempotencyKey.length > MAX_KEY_LENGTH) {
+      throw new BadRequestException(
+        `Idempotency-Key must not exceed ${MAX_KEY_LENGTH} characters`,
       );
     }
 

--- a/src/idempotency/idempotency.integration-spec.ts
+++ b/src/idempotency/idempotency.integration-spec.ts
@@ -1,0 +1,99 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { IdempotencyService } from './idempotency.service';
+import { IdempotencyKey } from './idempotency.entity';
+import { TestDatabaseModule } from '../test/test-database.module';
+
+describe('IdempotencyService (integration)', () => {
+  let module: TestingModule;
+  let service: IdempotencyService;
+  let repo: Repository<IdempotencyKey>;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TestDatabaseModule,
+        TypeOrmModule.forFeature([IdempotencyKey]),
+        ConfigModule.forRoot({ isGlobal: true }),
+      ],
+      providers: [IdempotencyService],
+    }).compile();
+
+    service = module.get(IdempotencyService);
+    repo = module.get<Repository<IdempotencyKey>>(
+      getRepositoryToken(IdempotencyKey),
+    );
+  });
+
+  afterEach(async () => {
+    await module.close();
+  });
+
+  it('stores a record and retrieves it by key', async () => {
+    const key = 'integration-test-key-0001';
+    const hash = service.hashRequest('POST', '/transfers', { amount: 100 });
+
+    await service.store(key, hash, { id: 'tx-1' }, 201, 1);
+
+    const found = await service.findByKey(key);
+    expect(found).toBeDefined();
+    expect(found!.key).toBe(key);
+    expect(found!.requestHash).toBe(hash);
+    expect(found!.statusCode).toBe(201);
+    expect(found!.response).toEqual({ id: 'tx-1' });
+  });
+
+  it('returns null when key does not exist', async () => {
+    const result = await service.findByKey('nonexistent-key-xyz');
+    expect(result).toBeNull();
+  });
+
+  it('cleanup removes expired records and leaves valid ones', async () => {
+    const expiredKey = 'expired-key-0001';
+    const activeKey = 'active-key-0002';
+    const hash = service.hashRequest('POST', '/transfers', {});
+
+    const pastDate = new Date(Date.now() - 1000);
+    await repo.save({
+      key: expiredKey,
+      requestHash: hash,
+      response: {},
+      statusCode: 200,
+      expiresAt: pastDate,
+    });
+
+    await service.store(activeKey, hash, {}, 200, 24);
+
+    const removed = await service.cleanup();
+    expect(removed).toBeGreaterThanOrEqual(1);
+
+    expect(await service.findByKey(expiredKey)).toBeNull();
+    expect(await service.findByKey(activeKey)).not.toBeNull();
+  });
+
+  it('overwrites an existing record on duplicate store (upsert behaviour)', async () => {
+    const key = 'dup-key-0001';
+    const hash = service.hashRequest('POST', '/transfers', { amount: 50 });
+
+    await service.store(key, hash, { id: 'tx-1' }, 201, 1);
+    await service.store(key, hash, { id: 'tx-1', updated: true }, 201, 1);
+
+    const rows = await repo.find({ where: { key } });
+    expect(rows).toHaveLength(1);
+    expect((rows[0].response as { updated?: boolean }).updated).toBe(true);
+  });
+
+  it('hashRequest produces the same hash for identical inputs', () => {
+    const h1 = service.hashRequest('POST', '/transfers', { amount: 100 });
+    const h2 = service.hashRequest('POST', '/transfers', { amount: 100 });
+    expect(h1).toBe(h2);
+  });
+
+  it('hashRequest produces different hashes for different bodies', () => {
+    const h1 = service.hashRequest('POST', '/transfers', { amount: 100 });
+    const h2 = service.hashRequest('POST', '/transfers', { amount: 200 });
+    expect(h1).not.toBe(h2);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,8 +51,8 @@ async function bootstrap() {
   app.useGlobalFilters(new GlobalExceptionFilter());
   app.enableShutdownHooks();
 
-  const nodeEnv = process.env.NODE_ENV || 'development';
-  const swaggerEnabled = process.env.SWAGGER_ENABLED === 'true';
+  const nodeEnv = configService.get<string>('app.nodeEnv');
+  const swaggerEnabled = configService.get<boolean>('app.swaggerEnabled');
   if (nodeEnv !== 'production' || swaggerEnabled) {
     const swaggerConfig = new DocumentBuilder()
       .setTitle('NexaFx API')
@@ -67,7 +67,8 @@ async function bootstrap() {
     });
   }
 
-  await app.listen(process.env.PORT ?? 3000);
+  const port = configService.get<number>('app.port');
+  await app.listen(port);
 }
 
 void bootstrap();

--- a/src/test/test-database.module.ts
+++ b/src/test/test-database.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+/**
+ * In-memory SQLite TypeORM module for integration tests.
+ * Each test suite that imports this gets an isolated, empty database.
+ * Use TypeOrmModule.forFeature([Entity]) in your test module to register entities.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      autoLoadEntities: true,
+      synchronize: true,
+      dropSchema: true,
+    }),
+  ],
+  exports: [TypeOrmModule],
+})
+export class TestDatabaseModule {}


### PR DESCRIPTION
## Summary

Resolves 6 open Stellar Wave issues (200 pts each) in a single atomic PR. Issues 713 and 714 were already resolved by prior merged PRs — noted below.

### Issue #707 — `@nestjs/mapped-types` pinned to `*` wildcard

- [`package.json`](package.json): `"@nestjs/mapped-types": "*"` → `"@nestjs/mapped-types": "^2.1.1"` (latest stable, compatible with `@nestjs/common@^11`)
- Added `check:no-wildcard-deps` npm script that fails CI if any `*` dependency range is detected

---

### Issue #706 — `main.ts` reads `process.env.PORT` directly, bypassing ConfigService

- [`main.ts`](src/main.ts): replaced `process.env.PORT ?? 3000` with `configService.get<number>('app.port')`
- Also replaced raw `process.env.NODE_ENV` and `process.env.SWAGGER_ENABLED` reads with `configService.get(...)` — all bootstrap config now flows through the Zod-validated pipeline

---

### Issue #597 — `src/database/data-source.ts` missing, all migration commands fail

- Created [`src/database/data-source.ts`](src/database/data-source.ts) exporting a TypeORM `DataSource` with:
  - `entities: ['src/**/*.entity.ts']`
  - `migrations: ['src/database/migrations/*.ts']`
  - Same env vars as AppModule (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`)
- `migration:run`, `migration:revert`, `migration:generate`, and `seed` scripts now resolve without "file not found" errors

---

### Issue #598 — No integration test database setup

- [`src/test/test-database.module.ts`](src/test/test-database.module.ts): reusable `TestDatabaseModule` that configures TypeORM with `better-sqlite3` in-memory (already a devDependency). Each test suite gets a fresh, isolated schema via `dropSchema: true` + `synchronize: true`
- [`jest.integration.json`](jest.integration.json): Jest config targeting `**/*.integration-spec.ts` files with `--runInBand` isolation
- [`src/idempotency/idempotency.integration-spec.ts`](src/idempotency/idempotency.integration-spec.ts): reference integration spec for `IdempotencyService` covering store/retrieve, cleanup, upsert, and hash determinism against a real SQLite DB
- `package.json`: added `test:integration` script → `jest --config ./jest.integration.json --runInBand`

Closes #597 
Closes #598 
Closes #706 
Closes #707 

## Test plan

- [ ] `npm run test` — all unit specs pass (guard spec now covers min+max boundary, env.validation spec covers required WALLET_ENCRYPTION_KEY)
- [ ] `npm run test:integration` — IdempotencyService integration spec passes against SQLite in-memory
- [ ] `npm run check:no-wildcard-deps` — exits 0 (no wildcard deps remain)
- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] Setting `PORT=abc` triggers Zod startup error (not silent NaN coercion)
- [ ] Sending `Idempotency-Key` header with 256 chars returns `400 Bad Request`
- [ ] Omitting `WALLET_ENCRYPTION_KEY` from env triggers Zod startup error
- [ ] `npm run migration:run` resolves without "file not found" error