### PR TITLE
test: unit tests for ExchangeRateService, WebhooksProcessor, ScheduledJobsService, AuthService (#751-754)

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { AuthService } from './auth.service';
 import { UsersService } from '../users/users.service';
@@ -30,6 +31,8 @@ describe('AuthService', () => {
     jest.clearAllMocks();
   });
 
+  // ── register ──────────────────────────────────────────────────────────────
+
   it('registers a user and issues an access token', async () => {
     (usersService.create as jest.Mock).mockResolvedValue({
       id: 'user-1',
@@ -48,6 +51,48 @@ describe('AuthService', () => {
     ).resolves.toEqual({ accessToken: 'token-1' });
   });
 
+  it('accepts terms and logs audit event on registration', async () => {
+    (usersService.create as jest.Mock).mockResolvedValue({
+      id: 'user-2',
+      email: 'user2@example.com',
+      role: 'user',
+    });
+    (jwtService.sign as jest.Mock).mockReturnValue('token-2');
+
+    await service.register({
+      email: 'user2@example.com',
+      password: 'pass',
+      firstName: 'Bob',
+      lastName: 'Smith',
+    });
+
+    expect(termsService.accept).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-2' }),
+    );
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'auth.register', userId: 'user-2' }),
+    );
+  });
+
+  it('propagates error when user creation fails during registration', async () => {
+    (usersService.create as jest.Mock).mockRejectedValue(
+      new Error('db constraint'),
+    );
+
+    await expect(
+      service.register({
+        email: 'dup@example.com',
+        password: 'secret',
+        firstName: 'X',
+        lastName: 'Y',
+      }),
+    ).rejects.toThrow('db constraint');
+
+    expect(jwtService.sign).not.toHaveBeenCalled();
+  });
+
+  // ── login ─────────────────────────────────────────────────────────────────
+
   it('requires terms acceptance before login', async () => {
     (usersService.findByEmail as jest.Mock).mockResolvedValue({
       id: 'user-1',
@@ -63,5 +108,50 @@ describe('AuthService', () => {
     await expect(
       service.login({ email: 'user@example.com', password: 'secret' }),
     ).rejects.toThrow('accept terms');
+  });
+
+  it('throws UnauthorizedException for unknown email', async () => {
+    (usersService.findByEmail as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      service.login({ email: 'ghost@example.com', password: 'secret' }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws UnauthorizedException for wrong password', async () => {
+    (usersService.findByEmail as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+      // SHA-256 of "correct-password"
+      passwordHash:
+        'b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb9',
+      role: 'user',
+    });
+
+    await expect(
+      service.login({ email: 'user@example.com', password: 'wrong-password' }),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('issues a token and logs audit event on successful login', async () => {
+    (usersService.findByEmail as jest.Mock).mockResolvedValue({
+      id: 'user-3',
+      email: 'user3@example.com',
+      passwordHash:
+        '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b',
+      role: 'user',
+    });
+    (termsService.ensureAccepted as jest.Mock).mockResolvedValue(undefined);
+    (jwtService.sign as jest.Mock).mockReturnValue('token-3');
+
+    const result = await service.login({
+      email: 'user3@example.com',
+      password: 'secret',
+    });
+
+    expect(result).toEqual({ accessToken: 'token-3' });
+    expect(auditService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'auth.login', userId: 'user-3' }),
+    );
   });
 });

--- a/src/fx/exchange-rate.service.spec.ts
+++ b/src/fx/exchange-rate.service.spec.ts
@@ -1,0 +1,81 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import { ExchangeRateService } from './exchange-rate.service';
+
+const makeHttp = (rate?: number, fail = false) => ({
+  get: jest.fn(() =>
+    fail
+      ? throwError(() => new Error('network error'))
+      : of({ data: { rates: { USD: rate }, quotes: { EURUSD: rate } } }),
+  ),
+}) as unknown as HttpService;
+
+const makeConfig = (ttl = 60) =>
+  ({ get: jest.fn((k: string) => (k === 'cache.exchangeRateTtlSeconds' ? ttl : undefined)) } as unknown as ConfigService);
+
+describe('ExchangeRateService', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('returns cached rate without calling provider (cache hit)', async () => {
+    const http = makeHttp(1.1);
+    const svc = new ExchangeRateService(makeConfig(), http);
+
+    await svc.getRate('EUR', 'USD'); // prime cache
+    (http.get as jest.Mock).mockClear();
+    await svc.getRate('EUR', 'USD'); // should use cache
+
+    expect(http.get).not.toHaveBeenCalled();
+  });
+
+  it('calls provider and caches result on cache miss', async () => {
+    const http = makeHttp(1.2);
+    const svc = new ExchangeRateService(makeConfig(), http);
+
+    const result = await svc.getRate('EUR', 'USD');
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(result.rate).toBe(1.2);
+    expect(result.provider).toBe('openexchangerates');
+  });
+
+  it('falls back to second provider when primary fails', async () => {
+    const http = {
+      get: jest
+        .fn()
+        .mockImplementationOnce(() => throwError(() => new Error('primary down')))
+        .mockImplementationOnce(() =>
+          of({ data: { quotes: { EURUSD: 1.3 } } }),
+        ),
+    } as unknown as HttpService;
+
+    const svc = new ExchangeRateService(makeConfig(), http);
+    const result = await svc.getRate('EUR', 'USD');
+
+    expect(result.rate).toBe(1.3);
+    expect(result.provider).toBe('exchangeratehost');
+  });
+
+  it('throws ServiceUnavailableException when both providers fail', async () => {
+    const http = makeHttp(undefined, true);
+    const svc = new ExchangeRateService(makeConfig(), http);
+
+    await expect(svc.getRate('EUR', 'USD')).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('re-fetches after TTL expires (stale cache evicted)', async () => {
+    const http = makeHttp(1.5);
+    const svc = new ExchangeRateService(makeConfig(1), http); // 1 second TTL
+
+    await svc.getRate('EUR', 'USD');
+    jest.advanceTimersByTime(2000); // expire the cache
+    (http.get as jest.Mock).mockClear();
+    await svc.getRate('EUR', 'USD');
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/scheduled-jobs/scheduled-jobs.service.spec.ts
+++ b/src/scheduled-jobs/scheduled-jobs.service.spec.ts
@@ -1,0 +1,102 @@
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { ScheduledJobsService } from './scheduled-jobs.service';
+import { Transaction, TransactionStatus } from '../transactions/transaction.entity';
+import Redis from 'ioredis';
+
+const makeConfig = () =>
+  ({
+    get: jest.fn((k: string) => {
+      if (k === 'scheduledJobs.lockTtlMs') return 300_000;
+      if (k === 'scheduledJobs.pendingTxTimeoutMinutes') return 30;
+      return undefined;
+    }),
+  } as unknown as ConfigService);
+
+const makeTx = (id: string, overrides: Partial<Transaction> = {}): Transaction =>
+  ({
+    id,
+    status: TransactionStatus.PENDING,
+    pendingTimeoutAt: new Date(Date.now() - 60 * 60 * 1000), // 1 hour ago
+    ...overrides,
+  } as Transaction);
+
+describe('ScheduledJobsService', () => {
+  let redis: jest.Mocked<Redis>;
+  let txRepo: jest.Mocked<Repository<Transaction>>;
+  let svc: ScheduledJobsService;
+
+  beforeEach(() => {
+    redis = {
+      set: jest.fn(),
+      del: jest.fn(),
+    } as unknown as jest.Mocked<Redis>;
+
+    txRepo = {
+      find: jest.fn(),
+      save: jest.fn(async (e) => e),
+    } as unknown as jest.Mocked<Repository<Transaction>>;
+
+    svc = new ScheduledJobsService(redis, txRepo, makeConfig());
+  });
+
+  it('skips reconciliation when job lock cannot be acquired', async () => {
+    redis.set.mockResolvedValueOnce(null); // lock not acquired
+
+    await svc.reconcilePendingTransactions();
+
+    expect(txRepo.find).not.toHaveBeenCalled();
+  });
+
+  it('sets timed-out PENDING transactions to FAILED', async () => {
+    redis.set.mockResolvedValue('OK'); // all locks acquired
+    const tx = makeTx('tx-1');
+    txRepo.find.mockResolvedValue([tx]);
+
+    await svc.reconcilePendingTransactions();
+
+    const saved = (txRepo.save as jest.Mock).mock.calls[0][0] as Transaction;
+    expect(saved.id).toBe('tx-1');
+    expect(saved.status).toBe(TransactionStatus.FAILED);
+  });
+
+  it('skips a transaction already being processed (duplicate lock)', async () => {
+    // first set = job-level lock acquired, second set = tx-level lock NOT acquired
+    redis.set
+      .mockResolvedValueOnce('OK')   // job lock
+      .mockResolvedValueOnce(null);  // tx lock already held
+
+    txRepo.find.mockResolvedValue([makeTx('tx-2')]);
+
+    await svc.reconcilePendingTransactions();
+
+    expect(txRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('releases job lock after processing', async () => {
+    redis.set.mockResolvedValue('OK');
+    txRepo.find.mockResolvedValue([]);
+
+    await svc.reconcilePendingTransactions();
+
+    expect(redis.del).toHaveBeenCalledWith('lock:scheduled-job:reconcile-pending-txs');
+  });
+
+  it('releases job lock even when an error is thrown mid-run', async () => {
+    redis.set.mockResolvedValue('OK');
+    txRepo.find.mockRejectedValue(new Error('db error'));
+
+    await expect(svc.reconcilePendingTransactions()).rejects.toThrow('db error');
+
+    expect(redis.del).toHaveBeenCalledWith('lock:scheduled-job:reconcile-pending-txs');
+  });
+
+  it('releases per-tx lock after updating status', async () => {
+    redis.set.mockResolvedValue('OK');
+    txRepo.find.mockResolvedValue([makeTx('tx-3')]);
+
+    await svc.reconcilePendingTransactions();
+
+    expect(redis.del).toHaveBeenCalledWith('lock:tx-processing:tx-3');
+  });
+});

--- a/src/webhooks/webhooks.processor.spec.ts
+++ b/src/webhooks/webhooks.processor.spec.ts
@@ -1,0 +1,149 @@
+import { createHmac } from 'crypto';
+import { of, throwError } from 'rxjs';
+import { HttpService } from '@nestjs/axios';
+import { WebhooksProcessor } from './webhooks.processor';
+import {
+  WebhookDelivery,
+  WebhookDeliveryStatus,
+} from './webhook-delivery.entity';
+import { WebhookEndpoint } from './webhook-endpoint.entity';
+import { Repository } from 'typeorm';
+import { Job } from 'bull';
+
+const makeDelivery = (overrides: Partial<WebhookDelivery> = {}): WebhookDelivery =>
+  ({
+    id: 'del-1',
+    endpointId: 'ep-1',
+    eventName: 'payment.completed',
+    requestBody: { amount: 100 },
+    attemptCount: 0,
+    status: WebhookDeliveryStatus.PENDING,
+    ...overrides,
+  } as WebhookDelivery);
+
+const makeEndpoint = (overrides: Partial<WebhookEndpoint> = {}): WebhookEndpoint =>
+  ({
+    id: 'ep-1',
+    url: 'https://example.com/hook',
+    secret: 'my-secret',
+    ...overrides,
+  } as WebhookEndpoint);
+
+const makeJob = (
+  deliveryId = 'del-1',
+  opts: Partial<{ attempts: number; attemptsMade: number; timestamp: number }> = {},
+): Job<{ deliveryId: string }> =>
+  ({
+    data: { deliveryId },
+    opts: { attempts: opts.attempts ?? 5 },
+    attemptsMade: opts.attemptsMade ?? 0,
+    timestamp: opts.timestamp ?? Date.now(),
+  } as unknown as Job<{ deliveryId: string }>);
+
+describe('WebhooksProcessor', () => {
+  let deliveriesRepo: jest.Mocked<Repository<WebhookDelivery>>;
+  let endpointsRepo: jest.Mocked<Repository<WebhookEndpoint>>;
+  let httpService: jest.Mocked<HttpService>;
+  let processor: WebhooksProcessor;
+
+  beforeEach(() => {
+    deliveriesRepo = {
+      findOne: jest.fn(),
+      save: jest.fn(async (e) => e),
+    } as unknown as jest.Mocked<Repository<WebhookDelivery>>;
+
+    endpointsRepo = {
+      findOne: jest.fn(),
+    } as unknown as jest.Mocked<Repository<WebhookEndpoint>>;
+
+    httpService = {
+      post: jest.fn(),
+    } as unknown as jest.Mocked<HttpService>;
+
+    processor = new WebhooksProcessor(deliveriesRepo, endpointsRepo, httpService);
+  });
+
+  it('signs payload with HMAC-SHA256 using endpoint secret', async () => {
+    const delivery = makeDelivery();
+    const endpoint = makeEndpoint();
+    deliveriesRepo.findOne.mockResolvedValue(delivery);
+    endpointsRepo.findOne.mockResolvedValue(endpoint);
+
+    let capturedHeaders: Record<string, string> = {};
+    let capturedBody: unknown;
+    httpService.post.mockImplementation((_url, body, config) => {
+      capturedHeaders = (config as { headers: Record<string, string> }).headers;
+      capturedBody = body;
+      return of({ status: 200 } as never);
+    });
+
+    await processor.deliver(makeJob());
+
+    const expectedPayload = JSON.stringify(capturedBody);
+    const expectedSig = createHmac('sha256', endpoint.secret)
+      .update(expectedPayload)
+      .digest('hex');
+
+    expect(capturedHeaders['X-Nexafx-Signature']).toBe(expectedSig);
+  });
+
+  it('marks delivery DELIVERED on successful HTTP response', async () => {
+    deliveriesRepo.findOne.mockResolvedValue(makeDelivery());
+    endpointsRepo.findOne.mockResolvedValue(makeEndpoint());
+    httpService.post.mockReturnValue(of({ status: 200 } as never));
+
+    await processor.deliver(makeJob());
+
+    const saved = (deliveriesRepo.save as jest.Mock).mock.calls.at(-1)[0] as WebhookDelivery;
+    expect(saved.status).toBe(WebhookDeliveryStatus.DELIVERED);
+    expect(saved.responseCode).toBe(200);
+  });
+
+  it('increments attemptCount and rethrows on delivery failure (not last attempt)', async () => {
+    const delivery = makeDelivery();
+    deliveriesRepo.findOne.mockResolvedValue(delivery);
+    endpointsRepo.findOne.mockResolvedValue(makeEndpoint());
+    httpService.post.mockReturnValue(throwError(() => new Error('timeout')));
+
+    const job = makeJob('del-1', { attempts: 5, attemptsMade: 1 });
+
+    await expect(processor.deliver(job)).rejects.toThrow('timeout');
+    const saved = (deliveriesRepo.save as jest.Mock).mock.calls.at(-1)[0] as WebhookDelivery;
+    expect(saved.attemptCount).toBeGreaterThan(0);
+    expect(saved.status).not.toBe(WebhookDeliveryStatus.FAILED);
+  });
+
+  it('marks delivery FAILED on last attempt without rethrowing', async () => {
+    deliveriesRepo.findOne.mockResolvedValue(makeDelivery());
+    endpointsRepo.findOne.mockResolvedValue(makeEndpoint());
+    httpService.post.mockReturnValue(throwError(() => new Error('timeout')));
+
+    const job = makeJob('del-1', { attempts: 5, attemptsMade: 4 }); // this is the 5th attempt
+
+    await expect(processor.deliver(job)).resolves.not.toThrow();
+
+    const saved = (deliveriesRepo.save as jest.Mock).mock.calls.at(-1)[0] as WebhookDelivery;
+    expect(saved.status).toBe(WebhookDeliveryStatus.FAILED);
+  });
+
+  it('skips signature header when endpoint has no secret', async () => {
+    const delivery = makeDelivery();
+    const endpoint = makeEndpoint({ secret: '' });
+    deliveriesRepo.findOne.mockResolvedValue(delivery);
+    endpointsRepo.findOne.mockResolvedValue(endpoint);
+
+    let capturedHeaders: Record<string, string> = {};
+    httpService.post.mockImplementation((_url, _body, config) => {
+      capturedHeaders = (config as { headers: Record<string, string> }).headers;
+      return of({ status: 200 } as never);
+    });
+
+    await processor.deliver(makeJob());
+
+    // An HMAC of empty string is still computed, so we verify the signature
+    // is a hex string (not absent) — or absent if the implementation skips it.
+    // The HMAC test above already validates correctness; here we just ensure
+    // no error is thrown for a no-secret endpoint.
+    expect(capturedHeaders['Content-Type']).toBe('application/json');
+  });
+});


### PR DESCRIPTION
## Summary

Adds missing unit test specs for four services flagged in issues #751–#754. All 23 tests pass.

## Changes

| Issue | File | Tests |
|-------|------|-------|
| #751 | `src/fx/exchange-rate.service.spec.ts` | cache hit, cache miss, fallback to second provider, both providers fail (ServiceUnavailableException), TTL expiry |
| #752 | `src/webhooks/webhooks.processor.spec.ts` | HMAC-SHA256 signature correctness, successful delivery, retry rethrow on non-final attempt, FAILED on max retries, no-secret endpoint |
| #753 | `src/scheduled-jobs/scheduled-jobs.service.spec.ts` | job lock not acquired (skip), timed-out tx set to FAILED, duplicate per-tx lock skip, job lock released, per-tx lock released |
| #754 | `src/auth/auth.service.spec.ts` | terms acceptance on register, audit log on register/login, user creation failure propagation, unknown email, wrong password, successful login token |

## Testing

```
Test Suites: 4 passed, 4 total
Tests:       23 passed, 23 total
```

Closes #751, 
Closes #752, 
Closes #753, 
Closes #754