### PR TITLE
feat: admin mutation audit logs with before/after diff (#810)

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,19 +1,25 @@
 import { CacheInterceptor, CacheTTL, CacheKey } from '@nestjs/cache-manager';
 import {
   BadRequestException,
+  Body,
   Controller,
   Get,
   Param,
+  Patch,
+  Req,
   Res,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { join, resolve, normalize } from 'path';
 import { AdminService } from './admin.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminRoleGuard } from '../common/guards/admin-role.guard';
 import { IpAllowlistGuard } from '../common/guards/ip-allowlist.guard';
+import { UpdateTransactionStatusDto } from './dto/update-transaction-status.dto';
+import { UpdateUserStatusDto } from './dto/update-user-status.dto';
+import { UpdateUserRoleDto } from './dto/update-user-role.dto';
 
 const adminStatsTtlSeconds = parseInt(
   process.env.CACHE_ADMIN_STATS_TTL_SECONDS || '60',
@@ -22,10 +28,19 @@ const adminStatsTtlSeconds = parseInt(
 
 const KYC_UPLOAD_BASE = resolve(process.cwd(), 'uploads', 'kyc');
 
+interface AuthenticatedRequest extends Request {
+  user: {
+    id: string;
+    email: string;
+    role: string;
+    isEmailVerified: boolean;
+  };
+}
+
 function assertSafePathSegment(segment: string, paramName: string): void {
   if (/[/\\]/.test(segment) || segment.includes('..')) {
     throw new BadRequestException(
-      `Invalid path segment in ${paramName} â€” traversal sequences are not permitted`,
+      `Invalid path segment in ${paramName} — traversal sequences are not permitted`,
     );
   }
 }
@@ -41,6 +56,51 @@ export class AdminController {
   @Get('stats')
   getStats() {
     return this.adminService.getStats();
+  }
+
+  @UseGuards(JwtAuthGuard, AdminRoleGuard, IpAllowlistGuard)
+  @Patch('transactions/:id/status')
+  overrideTransactionStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateTransactionStatusDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.adminService.overrideTransactionStatus(
+      id,
+      dto.status,
+      req.user.id,
+      dto.reason,
+    );
+  }
+
+  @UseGuards(JwtAuthGuard, AdminRoleGuard, IpAllowlistGuard)
+  @Patch('users/:id/status')
+  updateUserStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateUserStatusDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.adminService.updateUserStatus(
+      id,
+      dto.isActive,
+      req.user.id,
+      dto.reason,
+    );
+  }
+
+  @UseGuards(JwtAuthGuard, AdminRoleGuard, IpAllowlistGuard)
+  @Patch('users/:id/role')
+  updateUserRole(
+    @Param('id') id: string,
+    @Body() dto: UpdateUserRoleDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.adminService.updateUserRole(
+      id,
+      dto.role,
+      req.user.id,
+      dto.reason,
+    );
   }
 
   @UseGuards(JwtAuthGuard, AdminRoleGuard, IpAllowlistGuard)

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -10,6 +10,7 @@ import { SupportTicket } from '../support/support-ticket.entity';
 import { WebhookEndpoint } from '../webhooks/webhook-endpoint.entity';
 import { AmlAlert } from '../aml/aml-alert.entity';
 import { SecurityModule } from '../common/security.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { SecurityModule } from '../common/security.module';
       AmlAlert,
     ]),
     SecurityModule,
+    AuditModule,
   ],
   controllers: [AdminController],
   providers: [AdminService, AdminCacheInvalidationService],

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,0 +1,223 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { AuditService } from '../audit/audit.service';
+import { User, UserRole, KycStatus } from '../users/user.entity';
+import { Transaction, TransactionStatus } from '../transactions/transaction.entity';
+import { KycDocument } from '../kyc/kyc-document.entity';
+import { SupportTicket } from '../support/support-ticket.entity';
+import { WebhookEndpoint } from '../webhooks/webhook-endpoint.entity';
+import { AmlAlert } from '../aml/aml-alert.entity';
+
+const mockRepository = () => ({
+  count: jest.fn(),
+  findOne: jest.fn(),
+  save: jest.fn(),
+});
+
+const mockAuditService = () => ({
+  log: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let usersRepo: ReturnType<typeof mockRepository>;
+  let transactionsRepo: ReturnType<typeof mockRepository>;
+  let auditService: ReturnType<typeof mockAuditService>;
+
+  const adminUserId = 'admin-uuid-001';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        { provide: getRepositoryToken(User), useFactory: mockRepository },
+        { provide: getRepositoryToken(Transaction), useFactory: mockRepository },
+        { provide: getRepositoryToken(KycDocument), useFactory: mockRepository },
+        { provide: getRepositoryToken(SupportTicket), useFactory: mockRepository },
+        { provide: getRepositoryToken(WebhookEndpoint), useFactory: mockRepository },
+        { provide: getRepositoryToken(AmlAlert), useFactory: mockRepository },
+        { provide: AuditService, useFactory: mockAuditService },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+    usersRepo = module.get(getRepositoryToken(User));
+    transactionsRepo = module.get(getRepositoryToken(Transaction));
+    auditService = module.get(AuditService);
+  });
+
+  describe('overrideTransactionStatus', () => {
+    const mockTransaction: Partial<Transaction> = {
+      id: 'tx-001',
+      status: TransactionStatus.PENDING,
+      amount: 100,
+      currency: 'USD',
+      senderId: 'sender-001',
+      receiverId: 'receiver-001',
+      reference: 'REF-001',
+    };
+
+    it('should update status and log before/after diff', async () => {
+      const updated = { ...mockTransaction, status: TransactionStatus.COMPLETED };
+      transactionsRepo.findOne.mockResolvedValue({ ...mockTransaction });
+      transactionsRepo.save.mockResolvedValue(updated);
+
+      const result = await service.overrideTransactionStatus(
+        'tx-001',
+        TransactionStatus.COMPLETED,
+        adminUserId,
+        'Payment confirmed manually',
+      );
+
+      expect(result.status).toBe(TransactionStatus.COMPLETED);
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: adminUserId,
+          action: 'admin.transaction.status_override',
+          entityType: 'transaction',
+          entityId: 'tx-001',
+          before: expect.objectContaining({ status: TransactionStatus.PENDING }),
+          after: expect.objectContaining({ status: TransactionStatus.COMPLETED }),
+          reason: 'Payment confirmed manually',
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when transaction does not exist', async () => {
+      transactionsRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.overrideTransactionStatus(
+          'nonexistent',
+          TransactionStatus.COMPLETED,
+          adminUserId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(auditService.log).not.toHaveBeenCalled();
+    });
+
+    it('should log without reason when reason is omitted', async () => {
+      const updated = { ...mockTransaction, status: TransactionStatus.FAILED };
+      transactionsRepo.findOne.mockResolvedValue({ ...mockTransaction });
+      transactionsRepo.save.mockResolvedValue(updated);
+
+      await service.overrideTransactionStatus(
+        'tx-001',
+        TransactionStatus.FAILED,
+        adminUserId,
+      );
+
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: undefined }),
+      );
+    });
+  });
+
+  describe('updateUserStatus', () => {
+    const mockUser: Partial<User> = {
+      id: 'user-001',
+      email: 'user@example.com',
+      isActive: true,
+      role: UserRole.USER,
+      kycStatus: KycStatus.APPROVED,
+    };
+
+    it('should suspend user and log before/after diff', async () => {
+      const updated = { ...mockUser, isActive: false };
+      usersRepo.findOne.mockResolvedValue({ ...mockUser });
+      usersRepo.save.mockResolvedValue(updated);
+
+      const result = await service.updateUserStatus(
+        'user-001',
+        false,
+        adminUserId,
+        'Suspicious activity detected',
+      );
+
+      expect(result.isActive).toBe(false);
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: adminUserId,
+          action: 'admin.user.suspended',
+          entityType: 'user',
+          entityId: 'user-001',
+          before: expect.objectContaining({ isActive: true }),
+          after: expect.objectContaining({ isActive: false }),
+          reason: 'Suspicious activity detected',
+        }),
+      );
+    });
+
+    it('should activate user and use activated action', async () => {
+      const inactiveUser = { ...mockUser, isActive: false };
+      const updated = { ...mockUser, isActive: true };
+      usersRepo.findOne.mockResolvedValue({ ...inactiveUser });
+      usersRepo.save.mockResolvedValue(updated);
+
+      await service.updateUserStatus('user-001', true, adminUserId, 'Appeal approved');
+
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'admin.user.activated' }),
+      );
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateUserStatus('nonexistent', false, adminUserId),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(auditService.log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateUserRole', () => {
+    const mockUser: Partial<User> = {
+      id: 'user-001',
+      email: 'user@example.com',
+      isActive: true,
+      role: UserRole.USER,
+      kycStatus: KycStatus.APPROVED,
+    };
+
+    it('should change role and log before/after diff', async () => {
+      const updated = { ...mockUser, role: UserRole.COMPLIANCE };
+      usersRepo.findOne.mockResolvedValue({ ...mockUser });
+      usersRepo.save.mockResolvedValue(updated);
+
+      const result = await service.updateUserRole(
+        'user-001',
+        UserRole.COMPLIANCE,
+        adminUserId,
+        'Promoted to compliance team',
+      );
+
+      expect(result.role).toBe(UserRole.COMPLIANCE);
+      expect(auditService.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: adminUserId,
+          action: 'admin.user.role_changed',
+          entityType: 'user',
+          entityId: 'user-001',
+          before: expect.objectContaining({ role: UserRole.USER }),
+          after: expect.objectContaining({ role: UserRole.COMPLIANCE }),
+          reason: 'Promoted to compliance team',
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      usersRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateUserRole('nonexistent', UserRole.ADMIN, adminUserId),
+      ).rejects.toThrow(NotFoundException);
+
+      expect(auditService.log).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,12 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { User } from '../users/user.entity';
-import { Transaction } from '../transactions/transaction.entity';
+import { User, UserRole } from '../users/user.entity';
+import { Transaction, TransactionStatus } from '../transactions/transaction.entity';
 import { KycDocument } from '../kyc/kyc-document.entity';
 import { SupportTicket } from '../support/support-ticket.entity';
 import { WebhookEndpoint } from '../webhooks/webhook-endpoint.entity';
 import { AmlAlert } from '../aml/aml-alert.entity';
+import { AuditService } from '../audit/audit.service';
 
 export interface AdminStats {
   users: number;
@@ -32,6 +33,7 @@ export class AdminService {
     private readonly webhooksRepository: Repository<WebhookEndpoint>,
     @InjectRepository(AmlAlert)
     private readonly alertsRepository: Repository<AmlAlert>,
+    private readonly auditService: AuditService,
   ) {}
 
   async getStats(): Promise<AdminStats> {
@@ -59,5 +61,132 @@ export class AdminService {
       webhookEndpoints,
       amlAlerts,
     };
+  }
+
+  async overrideTransactionStatus(
+    transactionId: string,
+    newStatus: TransactionStatus,
+    adminUserId: string,
+    reason?: string,
+  ): Promise<Transaction> {
+    const transaction = await this.transactionsRepository.findOne({
+      where: { id: transactionId },
+    });
+    if (!transaction) {
+      throw new NotFoundException(`Transaction ${transactionId} not found`);
+    }
+
+    const before = {
+      status: transaction.status,
+      amount: transaction.amount,
+      currency: transaction.currency,
+      senderId: transaction.senderId,
+      receiverId: transaction.receiverId,
+      reference: transaction.reference,
+    };
+
+    transaction.status = newStatus;
+    const updated = await this.transactionsRepository.save(transaction);
+
+    await this.auditService.log({
+      userId: adminUserId,
+      action: 'admin.transaction.status_override',
+      entityType: 'transaction',
+      entityId: transactionId,
+      before,
+      after: {
+        status: updated.status,
+        amount: updated.amount,
+        currency: updated.currency,
+        senderId: updated.senderId,
+        receiverId: updated.receiverId,
+        reference: updated.reference,
+      },
+      reason,
+    });
+
+    return updated;
+  }
+
+  async updateUserStatus(
+    targetUserId: string,
+    isActive: boolean,
+    adminUserId: string,
+    reason?: string,
+  ): Promise<User> {
+    const user = await this.usersRepository.findOne({
+      where: { id: targetUserId },
+    });
+    if (!user) {
+      throw new NotFoundException(`User ${targetUserId} not found`);
+    }
+
+    const before = {
+      isActive: user.isActive,
+      role: user.role,
+      kycStatus: user.kycStatus,
+      email: user.email,
+    };
+
+    user.isActive = isActive;
+    const updated = await this.usersRepository.save(user);
+
+    await this.auditService.log({
+      userId: adminUserId,
+      action: isActive ? 'admin.user.activated' : 'admin.user.suspended',
+      entityType: 'user',
+      entityId: targetUserId,
+      before,
+      after: {
+        isActive: updated.isActive,
+        role: updated.role,
+        kycStatus: updated.kycStatus,
+        email: updated.email,
+      },
+      reason,
+    });
+
+    return updated;
+  }
+
+  async updateUserRole(
+    targetUserId: string,
+    newRole: UserRole,
+    adminUserId: string,
+    reason?: string,
+  ): Promise<User> {
+    const user = await this.usersRepository.findOne({
+      where: { id: targetUserId },
+    });
+    if (!user) {
+      throw new NotFoundException(`User ${targetUserId} not found`);
+    }
+
+    const before = {
+      isActive: user.isActive,
+      role: user.role,
+      kycStatus: user.kycStatus,
+      email: user.email,
+    };
+
+    user.role = newRole;
+    const updated = await this.usersRepository.save(user);
+
+    await this.auditService.log({
+      userId: adminUserId,
+      action: 'admin.user.role_changed',
+      entityType: 'user',
+      entityId: targetUserId,
+      before,
+      after: {
+        isActive: updated.isActive,
+        role: updated.role,
+        kycStatus: updated.kycStatus,
+        email: updated.email,
+      },
+      reason,
+    });
+
+    return updated;
   }
 }

--- a/src/admin/dto/update-transaction-status.dto.ts
+++ b/src/admin/dto/update-transaction-status.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { TransactionStatus } from '../../transactions/transaction.entity';
+
+export class UpdateTransactionStatusDto {
+  @IsEnum(TransactionStatus)
+  status!: TransactionStatus;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/src/admin/dto/update-user-role.dto.ts
+++ b/src/admin/dto/update-user-role.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { UserRole } from '../../users/user.entity';
+
+export class UpdateUserRoleDto {
+  @IsEnum(UserRole)
+  role!: UserRole;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/src/admin/dto/update-user-status.dto.ts
+++ b/src/admin/dto/update-user-status.dto.ts
@@ -1,0 +1,11 @@
+import { IsBoolean, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateUserStatusDto {
+  @IsBoolean()
+  isActive!: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/src/audit/audit-log.entity.ts
+++ b/src/audit/audit-log.entity.ts
@@ -26,11 +26,14 @@ export class AuditLog {
   @Column({ nullable: true })
   entityId!: string;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   before!: Record<string, unknown>;
 
-  @Column({ type: 'simple-json', nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
   after!: Record<string, unknown>;
+
+  @Column({ nullable: true })
+  reason!: string;
 
   @Column({ nullable: true })
   ipAddress!: string;

--- a/src/audit/audit.service.ts
+++ b/src/audit/audit.service.ts
@@ -11,6 +11,7 @@ export interface AuditEvent {
   entityId?: string;
   before?: Record<string, unknown>;
   after?: Record<string, unknown>;
+  reason?: string;
   ipAddress?: string;
   userAgent?: string;
 }


### PR DESCRIPTION
- Add overrideTransactionStatus, updateUserStatus, updateUserRole to AdminService
- Capture entity state before/after each mutation in AuditLog
- Add reason column to audit_logs, upgrade before/after columns to jsonb
- Wire AuditModule into AdminModule
- Add UpdateTransactionStatusDto, UpdateUserStatusDto, UpdateUserRoleDto
- Add PATCH /admin/transactions/:id/status, /admin/users/:id/status, /admin/users/:id/role
- Unit tests covering before/after diff, NotFoundException, reason logging


closes #810 