### PR TITLE
fix: invalidate JWT tokens on password change (#823)

### DIFF
--- a/src/auth/strategies/jwt.strategy.spec.ts
+++ b/src/auth/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,81 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtPayload, JwtStrategy } from './jwt.strategy';
+import { UsersService } from '../../users/users.service';
+
+const mockConfig = {
+  get: (key: string) => {
+    if (key === 'jwt.secret') return 'test-secret';
+    return undefined;
+  },
+} as unknown as ConfigService;
+
+const makeStrategy = (usersService: Partial<UsersService>) =>
+  new JwtStrategy(mockConfig, usersService as UsersService);
+
+const basePayload = (iat: number): JwtPayload => ({
+  sub: 'user-1',
+  email: 'user@example.com',
+  role: 'user',
+  isEmailVerified: true,
+  iat,
+});
+
+describe('JwtStrategy.validate', () => {
+  it('returns user data when token is valid and no password change has occurred', async () => {
+    const usersService = {
+      findById: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        passwordChangedAt: null,
+      }),
+    };
+    const strategy = makeStrategy(usersService);
+    const result = await strategy.validate(basePayload(1000));
+    expect(result).toEqual({
+      id: 'user-1',
+      email: 'user@example.com',
+      role: 'user',
+      isEmailVerified: true,
+    });
+  });
+
+  it('rejects token issued before password change', async () => {
+    const changedAt = new Date('2024-01-01T12:00:00Z');
+    const iatBeforeChange = Math.floor(changedAt.getTime() / 1000) - 60;
+    const usersService = {
+      findById: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        passwordChangedAt: changedAt,
+      }),
+    };
+    const strategy = makeStrategy(usersService);
+    await expect(strategy.validate(basePayload(iatBeforeChange))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+
+  it('accepts token issued after password change', async () => {
+    const changedAt = new Date('2024-01-01T12:00:00Z');
+    const iatAfterChange = Math.floor(changedAt.getTime() / 1000) + 60;
+    const usersService = {
+      findById: jest.fn().mockResolvedValue({
+        id: 'user-1',
+        passwordChangedAt: changedAt,
+      }),
+    };
+    const strategy = makeStrategy(usersService);
+    await expect(strategy.validate(basePayload(iatAfterChange))).resolves.toMatchObject({
+      id: 'user-1',
+    });
+  });
+
+  it('rejects when user no longer exists', async () => {
+    const usersService = {
+      findById: jest.fn().mockResolvedValue(null),
+    };
+    const strategy = makeStrategy(usersService);
+    await expect(strategy.validate(basePayload(9999))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
+  });
+});

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -2,17 +2,22 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { UsersService } from '../../users/users.service';
 
 export interface JwtPayload {
   sub: string;
   email: string;
   role: string;
   isEmailVerified: boolean;
+  iat: number;
 }
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(config: ConfigService) {
+  constructor(
+    config: ConfigService,
+    private readonly usersService: UsersService,
+  ) {
     const secret = config.get<string>('jwt.secret');
     if (!secret) {
       throw new UnauthorizedException(
@@ -26,7 +31,17 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: JwtPayload) {
+  async validate(payload: JwtPayload) {
+    const user = await this.usersService.findById(payload.sub);
+    if (!user) {
+      throw new UnauthorizedException('User no longer exists');
+    }
+    if (
+      user.passwordChangedAt &&
+      payload.iat < Math.floor(user.passwordChangedAt.getTime() / 1000)
+    ) {
+      throw new UnauthorizedException('Token invalidated by password change');
+    }
     return {
       id: payload.sub,
       email: payload.email,

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -15,4 +15,3 @@ export const AppDataSource = new DataSource({
   migrationsTableName: 'typeorm_migrations',
 });
 
-export default AppDataSource;

--- a/src/migrations/1751000000000-AddPasswordChangedAtToUser.ts
+++ b/src/migrations/1751000000000-AddPasswordChangedAtToUser.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddPasswordChangedAtToUser1751000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'passwordChangedAt',
+        type: 'timestamp',
+        isNullable: true,
+        default: null,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('users', 'passwordChangedAt');
+  }
+}

--- a/src/users/user.entity.ts
+++ b/src/users/user.entity.ts
@@ -53,6 +53,9 @@ export class User {
   @Column({ default: true })
   isActive!: boolean;
 
+  @Column({ type: 'datetime', nullable: true, default: null })
+  passwordChangedAt!: Date | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -61,6 +61,13 @@ export class UsersService {
     return this.usersRepository.save(user);
   }
 
+  async updatePassword(id: string, newPasswordHash: string): Promise<void> {
+    const user = await this.findById(id);
+    user.passwordHash = newPasswordHash;
+    user.passwordChangedAt = new Date();
+    await this.usersRepository.save(user);
+  }
+
   sanitize(user: User): Omit<User, 'passwordHash'> {
     const { passwordHash: _, ...safe } = user;
     return safe;


### PR DESCRIPTION
- Add passwordChangedAt column to User entity
- Add updatePassword() to UsersService to stamp the timestamp
- JwtStrategy.validate() now rejects tokens issued before passwordChangedAt
- Add migration: AddPasswordChangedAtToUser
- Remove duplicate default export from data-source.ts
- Add unit tests covering all acceptance criteria

closes #823 