### PR TITLE
fix: KYC cascade, duplicate review, admin metrics, private API (#896-#899)

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { User, UserRole } from '../users/user.entity';
 import { Transaction, TransactionStatus } from '../transactions/transaction.entity';
 import { KycDocument } from '../kyc/kyc-document.entity';
+import { KycDocumentStatus } from '../kyc/kyc-document.entity';
 import { SupportTicket } from '../support/support-ticket.entity';
 import { WebhookEndpoint } from '../webhooks/webhook-endpoint.entity';
 import { AmlAlert } from '../aml/aml-alert.entity';
@@ -13,6 +14,7 @@ export interface AdminStats {
   users: number;
   transactions: number;
   kycDocuments: number;
+  pendingKyc: number;
   supportTickets: number;
   webhookEndpoints: number;
   amlAlerts: number;
@@ -41,6 +43,7 @@ export class AdminService {
       users,
       transactions,
       kycDocuments,
+      pendingKyc,
       supportTickets,
       webhookEndpoints,
       amlAlerts,
@@ -48,6 +51,7 @@ export class AdminService {
       this.usersRepository.count(),
       this.transactionsRepository.count(),
       this.kycRepository.count(),
+      this.kycRepository.count({ where: { status: KycDocumentStatus.PENDING } }),
       this.supportTicketsRepository.count(),
       this.webhooksRepository.count(),
       this.alertsRepository.count(),
@@ -57,6 +61,7 @@ export class AdminService {
       users,
       transactions,
       kycDocuments,
+      pendingKyc,
       supportTickets,
       webhookEndpoints,
       amlAlerts,

--- a/src/kyc/kyc-document.entity.ts
+++ b/src/kyc/kyc-document.entity.ts
@@ -4,7 +4,10 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   Index,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
+import { User } from '../users/user.entity';
 
 export enum KycDocumentStatus {
   PENDING = 'pending',
@@ -21,6 +24,10 @@ export class KycDocument {
 
   @Column({ type: 'uuid' })
   userId!: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user?: User;
 
   @Column()
   documentType!: string;

--- a/src/transactions/transactions.module.ts
+++ b/src/transactions/transactions.module.ts
@@ -14,6 +14,7 @@ import { SecurityModule } from '../common/security.module';
 import { IdempotencyModule } from '../idempotency/idempotency.module';
 import { FxModule } from '../fx/fx.module';
 import { FeesModule } from '../fees/fees.module';
+import { TermsModule } from '../terms/terms.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { FeesModule } from '../fees/fees.module';
     IdempotencyModule,
     FxModule,
     FeesModule,
+    TermsModule,
   ],
   controllers: [TransactionsController],
   providers: [TransactionsService, TransactionLimitService],

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -19,6 +19,7 @@ import { MailService } from '../mail/mail.service';
 import { UsersService } from '../users/users.service';
 import { TransactionLimitService } from './transaction-limit.service';
 import { TermsAcceptanceService } from '../terms/terms-acceptance.service';
+import { FeesService } from '../fees/fees.service';
 
 export interface TransferDto {
   senderId: string;
@@ -88,6 +89,7 @@ export class TransactionsService implements OnModuleInit {
     private readonly events: EventEmitter2,
     private readonly limitService: TransactionLimitService,
     private readonly feesService: FeesService,
+    private readonly termsService: TermsAcceptanceService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -232,7 +234,7 @@ export class TransactionsService implements OnModuleInit {
 
   async createDeposit(dto: DepositDto): Promise<Transaction> {
     await this.termsService.ensureAccepted(dto.userId);
-    const fee = this.calculateFee(dto.amount);
+    const fee = this.feesService.calculateFee(dto.amount);
     const totalChecked = dto.amount + fee.feeAmount; // #742: fee included in limit check
     await this.limitService.check(dto.userId, totalChecked, dto.currency);
 
@@ -243,7 +245,7 @@ export class TransactionsService implements OnModuleInit {
       currency: dto.currency,
       fee: fee.feeAmount,
       reference: dto.reference,
-      metadata: { ...dto.metadata, type: 'deposit', memo: this.generateStellarMemo(tx.id).value, fullTransactionId: tx.id },
+      metadata: { ...dto.metadata, type: 'deposit', fullTransactionId: tx.id },
       status: TransactionStatus.PENDING,
     });
     await this.txRepo.save(tx);
@@ -290,7 +292,6 @@ export class TransactionsService implements OnModuleInit {
       );
     }
 
-    const fee = this.calculateFee(dto.amount);
     const totalChecked = dto.amount + fee.feeAmount; // #742: fee included in limit check
     await this.limitService.check(dto.userId, totalChecked, dto.currency);
 
@@ -345,7 +346,7 @@ export class TransactionsService implements OnModuleInit {
 
   async createSwap(dto: SwapDto): Promise<Transaction> {
     await this.termsService.ensureAccepted(dto.userId);
-    const fee = this.calculateFee(dto.fromAmount);
+    const fee = this.feesService.calculateFee(dto.fromAmount);
     const totalChecked = dto.fromAmount + fee.feeAmount; // #742: fee included in limit check
     await this.limitService.check(dto.userId, totalChecked, dto.fromCurrency);
 


### PR DESCRIPTION
## Changes

- **#896**: Added `@ManyToOne` relation to User with `onDelete: 'CASCADE'` in KycDocument entity to ensure referential integrity when users are deleted
- **#897**: Verified — only one review endpoint exists in both controller and service, no duplicates to consolidate
- **#898**: Added `pendingKyc` count to admin stats by querying KYC documents with PENDING status, fixing the hardcoded 0
- **#899**: Verified — no `as any` pattern found in createSwap; also fixed missing `FeesService` import, missing `TermsAcceptanceService` injection, removed duplicate `const fee` in `createWithdrawal`, and removed reference to non-existent `generateStellarMemo` method

Closes #896
Closes #897
Closes #898
Closes #899