### PR TITLE
fix: swap parseFloat, CurrentUser decorator, IP capture, single-tx limit (#900-#903)

### DIFF
--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (data: string | undefined, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return data ? request.user?.[data] : request.user;
+  },
+);

--- a/src/transactions/transaction-limit.service.ts
+++ b/src/transactions/transaction-limit.service.ts
@@ -4,6 +4,7 @@ import { ExchangeRateService } from '../fx/exchange-rate.service';
 /** Daily limit in USD equivalent (configurable via env). */
 const DAILY_LIMIT_USD = parseFloat(process.env.DAILY_LIMIT_USD ?? '50000');
 const MONTHLY_LIMIT_USD = parseFloat(process.env.MONTHLY_LIMIT_USD ?? '500000');
+const SINGLE_TX_LIMIT_USD = parseFloat(process.env.SINGLE_TX_LIMIT_USD ?? '25000');
 
 /** In-memory accumulators keyed by `userId:YYYY-MM-DD` and `userId:YYYY-MM`. */
 const dailyTotals = new Map<string, number>();
@@ -21,6 +22,12 @@ export class TransactionLimitService {
    */
   async check(userId: string, amount: number, currency: string): Promise<void> {
     const amountUsd = await this.toUsd(amount, currency);
+
+    if (amountUsd > SINGLE_TX_LIMIT_USD) {
+      throw new BadRequestException(
+        `Transaction exceeds single-transaction USD-equivalent limit of $${SINGLE_TX_LIMIT_USD}`,
+      );
+    }
 
     const today = this.dateKey();
     const month = this.monthKey();

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -5,9 +5,10 @@ import {
   Body,
   Query,
   Param,
+  Ip,
+  Headers,
   HttpCode,
   HttpStatus,
-  Req,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
@@ -24,6 +25,7 @@ import { TransactionStatus } from './transaction.entity';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AdminRoleGuard } from '../common/guards/admin-role.guard';
 import { IpAllowlistGuard } from '../common/guards/ip-allowlist.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { Idempotent } from '../idempotency/idempotency.decorator';
 import { IdempotencyGuard } from '../idempotency/idempotency.guard';
 import { IdempotencyInterceptor } from '../idempotency/idempotency.interceptor';
@@ -50,8 +52,13 @@ export class TransactionsController {
   @Idempotent()
   @UseGuards(IdempotencyGuard)
   @UseInterceptors(IdempotencyInterceptor)
-  deposit(@Body() dto: DepositDto) {
-    return this.txService.createDeposit(dto);
+  deposit(
+    @Body() dto: DepositDto,
+    @CurrentUser('sub') userId: string,
+    @Ip() ip: string,
+    @Headers('user-agent') userAgent: string,
+  ) {
+    return this.txService.createDeposit({ ...dto, userId, ipAddress: ip, userAgent });
   }
 
   @Post('withdrawal')
@@ -59,8 +66,11 @@ export class TransactionsController {
   @Idempotent()
   @UseGuards(IdempotencyGuard)
   @UseInterceptors(IdempotencyInterceptor)
-  withdrawal(@Body() dto: WithdrawalDto) {
-    return this.txService.createWithdrawal(dto);
+  withdrawal(
+    @Body() dto: WithdrawalDto,
+    @CurrentUser('sub') userId: string,
+  ) {
+    return this.txService.createWithdrawal({ ...dto, userId });
   }
 
   @Post('swap')
@@ -68,8 +78,13 @@ export class TransactionsController {
   @Idempotent()
   @UseGuards(IdempotencyGuard)
   @UseInterceptors(IdempotencyInterceptor)
-  swap(@Body() dto: SwapDto) {
-    return this.txService.createSwap(dto);
+  swap(
+    @Body() dto: SwapDto,
+    @CurrentUser('sub') userId: string,
+    @Ip() ip: string,
+    @Headers('user-agent') userAgent: string,
+  ) {
+    return this.txService.createSwap({ ...dto, userId, ipAddress: ip, userAgent });
   }
 
   @Get()
@@ -102,10 +117,10 @@ export class TransactionsController {
   reverse(
     @Param('id') id: string,
     @Body() body: ReverseTransactionDto,
-    @Req() request: AuthenticatedRequest,
+    @CurrentUser('sub') userId: string,
   ) {
     return this.txService.reverseTransaction(id, {
-      reversedBy: request.user?.sub ?? '',
+      reversedBy: userId ?? '',
       reason: body.reason,
     });
   }

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -48,6 +48,8 @@ export interface DepositDto {
   currency: string;
   reference: string;
   metadata?: Record<string, unknown>;
+  ipAddress?: string;
+  userAgent?: string;
 }
 
 export interface WithdrawalDto {
@@ -67,6 +69,8 @@ export interface SwapDto {
   toCurrency: string;
   reference: string;
   metadata?: Record<string, unknown>;
+  ipAddress?: string;
+  userAgent?: string;
 }
 
 const MAX_RETRIES = 3;
@@ -350,7 +354,7 @@ export class TransactionsService implements OnModuleInit {
     await this.limitService.check(dto.userId, totalChecked, dto.fromCurrency);
 
     const balance = await this.walletsService.getBalance(dto.userId, dto.fromCurrency);
-    if (balance.balance < totalChecked) {
+    if (new Big(String(balance.balance)).lt(totalChecked)) {
       throw new BadRequestException('Insufficient balance including fee');
     }
 


### PR DESCRIPTION
## Changes

- **#900**: Replaced parseFloat balance check with Big.js for precise comparison
- **#901**: Added @CurrentUser() decorator for typed user access on financial endpoints
- **#902**: Added IP address and user-agent capture to deposit and swap endpoints
- **#903**: Added single-transaction USD limit enforcement

Closes #900
Closes #901
Closes #902
Closes #903