### PR TITLE
fix: admin IP CIDR matching, API key CSPRNG, AML role check, rate limit fail-closed

### DIFF
--- a/src/admin/admin-ip-allowlist.middleware.ts
+++ b/src/admin/admin-ip-allowlist.middleware.ts
@@ -23,6 +23,36 @@ export class AdminIpAllowlistMiddleware {
   }
 
   private isIpInCidr(ip: string, cidr: string): boolean {
-    return true;
+    try {
+      const parts = cidr.split('/');
+      const range = parts[0] ?? '';
+      const prefixStr = parts[1] ?? '';
+      const prefix = parseInt(prefixStr, 10);
+
+      if (prefix === 0) return true;
+
+      const ipNum = this.ipToNumber(ip);
+      const rangeNum = this.ipToNumber(range);
+
+      if (ipNum === null || rangeNum === null) return false;
+
+      const mask = ~((1 << (32 - prefix)) - 1) >>> 0;
+      return (ipNum & mask) === (rangeNum & mask);
+    } catch {
+      return false;
+    }
+  }
+
+  private ipToNumber(ip: string): number | null {
+    const parts = ip.split('.');
+    if (parts.length !== 4) return null;
+
+    let num = 0;
+    for (const part of parts) {
+      const octet = parseInt(part, 10);
+      if (isNaN(octet) || octet < 0 || octet > 255) return null;
+      num = (num << 8) | octet;
+    }
+    return num >>> 0;
   }
 }

--- a/src/aml/aml.controller.ts
+++ b/src/aml/aml.controller.ts
@@ -31,14 +31,14 @@ interface AuthenticatedRequest {
 export class AmlController {
   constructor(private readonly screeningService: AmlScreeningService) {}
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, AdminRoleGuard)
   @Post('aml/screen/user')
   @HttpCode(HttpStatus.CREATED)
   screenUser(@Body() input: ScreenUserInput) {
     return this.screeningService.screenUser(input);
   }
 
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, AdminRoleGuard)
   @Post('aml/screen/transaction')
   @HttpCode(HttpStatus.CREATED)
   screenTransaction(@Body() input: ScreenTransactionInput) {

--- a/src/modules/api-keys/services/api-keys.service.ts
+++ b/src/modules/api-keys/services/api-keys.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { ApiKeyEntity } from '../entities/api-key.entity';
 
 @Injectable()
@@ -17,9 +17,7 @@ export class ApiKeysService {
   ) {}
 
   private generateApiKey(): string {
-    const bytes = createHash('sha256')
-      .update(`${Date.now()}-${Math.random().toString(36).substring(2)}`)
-      .digest('hex');
+    const bytes = randomBytes(32).toString('hex');
     return `nxf_${bytes}`;
   }
 

--- a/src/modules/endpoint-rate-limit/guards/endpoint-rate-limit.guard.ts
+++ b/src/modules/endpoint-rate-limit/guards/endpoint-rate-limit.guard.ts
@@ -48,7 +48,14 @@ export class EndpointRateLimitGuard implements CanActivate {
         throw error;
       }
       this.logger.error(`Endpoint rate limit check failed: ${error.message}`);
-      return true;
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Rate limit service unavailable',
+          error: 'Internal Server Error',
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 }


### PR DESCRIPTION
## Changes

### #1045 (SECURITY) — Admin IP allowlist CIDR matching
- Replaced stub `isIpInCidr` that always returned `true` with real IPv4 CIDR matching
- Uses bitwise AND with subnet mask for accurate network range comparison

### #1046 (SECURITY) — Cryptographic API key generation
- Replaced `Math.random()`-seeded SHA-256 with `crypto.randomBytes(32)`
- Provides 256 bits of cryptographically secure randomness

### #1047 (SECURITY) — AML screening role check
- Added `AdminRoleGuard` to both `screenUser` and `screenTransaction` endpoints
- Previously any authenticated user could screen arbitrary users

### #1048 (FIX) — Rate limit guard fails closed
- Changed catch block from `return true` to throw a 500 HttpException
- Prevents rate limiting from being silently disabled by internal errors

## Verification
- TypeScript errors: 734 (unchanged baseline, no new errors)

Closes #1045
Closes #1046
Closes #1047
Closes #1048