### PR TITLE
test: add coverage for account-freeze, user-deactivation, kyc-tiers, and AML services

### DIFF
--- a/src/aml/aml.service.spec.ts
+++ b/src/aml/aml.service.spec.ts
@@ -1,0 +1,37 @@
+import { AmlService, TransactionRecord } from './aml.service';
+
+describe('AmlService.checkVelocityBurst', () => {
+  const saveMock = jest.fn((v) => v);
+  const alertRepo = { create: (v: any) => v, save: saveMock } as any;
+  const config = { get: () => undefined } as any; // fall back to defaults (maxCount=10)
+  const events = { emit: jest.fn() } as any;
+  const service = new AmlService(alertRepo, config, events);
+
+  const makeTxs = (count: number): TransactionRecord[] =>
+    Array.from({ length: count }, (_, i) => ({
+      userId: 'user-1',
+      amount: 100,
+      currency: 'USD',
+      executedAt: new Date(),
+    }));
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does not alert just below the threshold', async () => {
+    await service.checkVelocityBurst('user-1', makeTxs(9));
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('does not alert exactly at the threshold (exclusive boundary)', async () => {
+    await service.checkVelocityBurst('user-1', makeTxs(10));
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('alerts once clearly over the threshold', async () => {
+    await service.checkVelocityBurst('user-1', makeTxs(11));
+    expect(saveMock).toHaveBeenCalledWith(
+      expect.objectContaining({ ruleTriggered: 'velocity-burst' }),
+    );
+    expect(events.emit).toHaveBeenCalledWith('aml.alert.created', expect.anything());
+  });
+});

--- a/src/modules/account-freeze/services/account-freeze.service.spec.ts
+++ b/src/modules/account-freeze/services/account-freeze.service.spec.ts
@@ -1,0 +1,54 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { AccountFreezeService } from './account-freeze.service';
+
+describe('AccountFreezeService', () => {
+  const findOneMock = jest.fn();
+  const createMock = jest.fn((v) => v);
+  const saveMock = jest.fn((v) => v);
+  const repo = { findOne: findOneMock, create: createMock, save: saveMock } as any;
+  const service = new AccountFreezeService(repo);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('freezes an active account and persists a freeze record', async () => {
+    findOneMock.mockResolvedValue(null);
+
+    const result = await service.freezeAccount('user-1', 'fraud review', 'admin-1');
+
+    expect(result).toMatchObject({ userId: 'user-1', isActive: true });
+    expect(saveMock).toHaveBeenCalled();
+  });
+
+  it('rejects freezing an already-frozen account', async () => {
+    findOneMock.mockResolvedValue({ userId: 'user-1', isActive: true });
+
+    await expect(
+      service.freezeAccount('user-1', 'fraud review', 'admin-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('unfreezes an active freeze', async () => {
+    findOneMock.mockResolvedValue({ userId: 'user-1', isActive: true });
+
+    const result = await service.unfreezeAccount('user-1', 'admin-1');
+
+    expect(result.isActive).toBe(false);
+    expect(result.unfrozenBy).toBe('admin-1');
+  });
+
+  it('throws when unfreezing an account with no active freeze', async () => {
+    findOneMock.mockResolvedValue(null);
+
+    await expect(service.unfreezeAccount('user-1', 'admin-1')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('reports whether an account is currently frozen', async () => {
+    findOneMock.mockResolvedValueOnce({ userId: 'user-1', isActive: true });
+    await expect(service.isAccountFrozen('user-1')).resolves.toBe(true);
+
+    findOneMock.mockResolvedValueOnce(null);
+    await expect(service.isAccountFrozen('user-1')).resolves.toBe(false);
+  });
+});

--- a/src/modules/kyc-tiers/services/kyc-tiers.service.spec.ts
+++ b/src/modules/kyc-tiers/services/kyc-tiers.service.spec.ts
@@ -1,0 +1,56 @@
+import { BadRequestException } from '@nestjs/common';
+import { KycTiersService } from './kyc-tiers.service';
+
+describe('KycTiersService', () => {
+  const upgradeFindOne = jest.fn();
+  const upgradeCreate = jest.fn((v) => v);
+  const upgradeSave = jest.fn((v) => v);
+  const userFindOne = jest.fn();
+  const userSave = jest.fn((v) => v);
+
+  const upgradeRepo = { findOne: upgradeFindOne, create: upgradeCreate, save: upgradeSave } as any;
+  const userRepo = { findOne: userFindOne, save: userSave } as any;
+  const service = new KycTiersService(upgradeRepo, userRepo);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('rejects a new request when one is already pending', async () => {
+    userFindOne.mockResolvedValue({ id: 'u1', metadata: { kycTier: 'BASIC' } });
+    upgradeFindOne.mockResolvedValue({ id: 'req-1', status: 'pending' });
+
+    await expect(
+      service.requestUpgrade('u1', { requestedTier: 'ADVANCED' } as any),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('approving a request updates the user tier', async () => {
+    upgradeFindOne.mockResolvedValue({
+      id: 'req-1',
+      status: 'pending',
+      userId: 'u1',
+      requestedTier: 'ADVANCED',
+    });
+    userFindOne.mockResolvedValue({ id: 'u1', metadata: {} });
+
+    await service.approve('req-1', 'admin-1');
+
+    expect(userSave).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { kycTier: 'ADVANCED' } }),
+    );
+  });
+
+  it('rejecting a request leaves the tier unchanged', async () => {
+    upgradeFindOne.mockResolvedValue({ id: 'req-1', status: 'pending', userId: 'u1' });
+
+    await service.reject('req-1', 'admin-1', 'insufficient docs');
+
+    expect(userFindOne).not.toHaveBeenCalled();
+    expect(userSave).not.toHaveBeenCalled();
+  });
+
+  it('getStatus returns the latest upgrade record for the user', async () => {
+    upgradeFindOne.mockResolvedValue({ id: 'req-1', userId: 'u1', status: 'pending' });
+
+    await expect(service.getStatus('u1')).resolves.toMatchObject({ userId: 'u1' });
+  });
+});

--- a/src/modules/user-deactivation/services/user-deactivation.service.spec.ts
+++ b/src/modules/user-deactivation/services/user-deactivation.service.spec.ts
@@ -1,0 +1,53 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { UserDeactivationService } from './user-deactivation.service';
+
+describe('UserDeactivationService', () => {
+  const findOneMock = jest.fn();
+  const createMock = jest.fn((v) => v);
+  const saveMock = jest.fn((v) => v);
+  const repo = { findOne: findOneMock, create: createMock, save: saveMock } as any;
+  const service = new UserDeactivationService(repo);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('deactivates an active user and stores the reason', async () => {
+    findOneMock.mockResolvedValue(null);
+
+    const result = await service.deactivate('user-1', { reason: 'fraud' } as any, 'admin-1');
+
+    expect(result).toMatchObject({ userId: 'user-1', reason: 'fraud', isActive: true });
+  });
+
+  it('rejects deactivating an already-deactivated user', async () => {
+    findOneMock.mockResolvedValue({ userId: 'user-1', isActive: true });
+
+    await expect(
+      service.deactivate('user-1', { reason: 'fraud' } as any, 'admin-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
+  });
+
+  it('reactivates a deactivated user', async () => {
+    findOneMock.mockResolvedValue({ userId: 'user-1', isActive: true });
+
+    const result = await service.reactivate('user-1', 'admin-1');
+
+    expect(result.isActive).toBe(false);
+    expect(result.reactivatedBy).toBe('admin-1');
+  });
+
+  it('throws when reactivating a user with no active deactivation', async () => {
+    findOneMock.mockResolvedValue(null);
+
+    await expect(service.reactivate('user-1', 'admin-1')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('isUserDeactivated reflects deactivated vs active users', async () => {
+    findOneMock.mockResolvedValueOnce({ userId: 'user-1', isActive: true });
+    await expect(service.isUserDeactivated('user-1')).resolves.toBe(true);
+
+    findOneMock.mockResolvedValueOnce(null);
+    await expect(service.isUserDeactivated('user-2')).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1053
Closes #1054
Closes #1055
Closes #1056

- `account-freeze.service.spec.ts`: freeze/unfreeze happy paths, already-frozen conflict, not-frozen not-found, isAccountFrozen status.
- `user-deactivation.service.spec.ts`: deactivate/reactivate happy paths, duplicate-deactivation conflict, reactivate-not-found, isUserDeactivated status.
- `kyc-tiers.service.spec.ts`: duplicate pending upgrade request rejected, approve updates user tier, reject leaves tier unchanged, getStatus.
- `aml.service.spec.ts`: checkVelocityBurst boundary cases (below / at / above threshold).