### PR TITLE
Fix exchange rate refresh, limit-check race, withdrawal stub, and rate alert persistence

### DIFF
--- a/src/exchange-rates/exchange-rates.service.ts
+++ b/src/exchange-rates/exchange-rates.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, MoreThan, Between } from 'typeorm';
+import { Repository, MoreThan, LessThanOrEqual, Between } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ExchangeRateCacheEntity } from './entities/exchange-rate-cache.entity';
 import { ExchangeRateHistoryEntity } from './entities/exchange-rate-history.entity';
@@ -168,12 +168,12 @@ export class ExchangeRatesService {
 
   @Cron(CronExpression.EVERY_MINUTE)
   async refreshExpiredRates() {
-    const expired = await this.cacheRepo.count({
-      where: { expiresAt: MoreThan(new Date()) },
+    const expiredCount = await this.cacheRepo.count({
+      where: { expiresAt: LessThanOrEqual(new Date()) },
     });
 
-    if (expired === 0) {
-      this.logger.log('Refreshing expired exchange rates');
+    if (expiredCount > 0) {
+      this.logger.log(`Refreshing ${expiredCount} expired exchange rate(s)`);
       await this.fetchAndCacheRates();
     }
   }

--- a/src/modules/wallets/controllers/withdrawal.controller.ts
+++ b/src/modules/wallets/controllers/withdrawal.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { IsNumber, IsString, IsUUID, Min } from 'class-validator';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { TransactionsService } from '../../../transactions/transactions.service';
 
 const beneficiaryCooldowns = new Map<string, number>();
 const BENEFICIARY_COOLDOWN_MS = 24 * 60 * 60 * 1000;
@@ -27,12 +28,14 @@ export class WithdrawalDto {
 }
 
 /**
- * Withdrawal endpoint — deducts from wallet balance and creates a transaction record.
- * Daily/monthly limits are enforced via SpendingLimitsService in full implementation.
+ * Withdrawal endpoint — deducts from wallet balance and creates a transaction record
+ * by delegating to the real, working TransactionsService.createWithdrawal() flow.
  */
 @Controller('api/v1/withdrawals')
 @UseGuards(JwtAuthGuard)
 export class WithdrawalController {
+  constructor(private readonly transactionsService: TransactionsService) {}
+
   @Post()
   @HttpCode(HttpStatus.CREATED)
   async initiateWithdrawal(
@@ -54,18 +57,15 @@ export class WithdrawalController {
         'New beneficiary requires a 24-hour cooldown before first transfer use',
       );
     }
-    // Full implementation: call WalletBalanceService.deduct() + TransactionsService.create()
-    return {
-      success: true,
-      data: {
-        transactionId: `txn_${Date.now()}`,
-        userId,
-        amount: dto.amount,
-        currency: dto.currency,
-        beneficiaryId: dto.beneficiaryId,
-        status: 'pending',
-        createdAt: new Date().toISOString(),
-      },
-    };
+
+    const transaction = await this.transactionsService.createWithdrawal({
+      userId,
+      amount: dto.amount,
+      currency: dto.currency,
+      reference: `wd_${userId}_${now}`,
+      destinationAddress: dto.beneficiaryId,
+    });
+
+    return { success: true, data: transaction };
   }
 }

--- a/src/rate-alerts/rate-alerts.service.ts
+++ b/src/rate-alerts/rate-alerts.service.ts
@@ -1,42 +1,34 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { RateAlertEntity } from './rate-alert.entity';
 
-export interface RateAlert {
-  id: string;
-  userId: string;
-  currencyPair: string;
-  targetRate: number;
-  direction: 'above' | 'below';
-  triggered: boolean;
-  createdAt: Date;
-}
+export type RateAlert = RateAlertEntity;
 
 @Injectable()
 export class RateAlertsService {
   private readonly logger = new Logger(RateAlertsService.name);
-  private alerts: RateAlert[] = [];
 
-  constructor(private readonly events: EventEmitter2) {}
+  constructor(
+    @InjectRepository(RateAlertEntity)
+    private readonly alertsRepo: Repository<RateAlertEntity>,
+    private readonly events: EventEmitter2,
+  ) {}
 
   async create(userId: string, currencyPair: string, targetRate: number, direction: 'above' | 'below'): Promise<RateAlert> {
-    const alert: RateAlert = {
-      id: Math.random().toString(36).slice(2),
-      userId, currencyPair, targetRate, direction,
-      triggered: false, createdAt: new Date(),
-    };
-    this.alerts.push(alert);
-    return alert;
+    const alert = this.alertsRepo.create({ userId, currencyPair, targetRate, direction, triggered: false });
+    return this.alertsRepo.save(alert);
   }
 
   async deactivate(alertId: string): Promise<void> {
-    const alert = this.alerts.find(a => a.id === alertId);
-    if (alert) alert.triggered = true;
+    await this.alertsRepo.update({ id: alertId }, { triggered: true });
   }
 
-  checkThresholds(rates: Record<string, number>): void {
-    for (const alert of this.alerts) {
-      if (alert.triggered) continue;
+  async checkThresholds(rates: Record<string, number>): Promise<void> {
+    const activeAlerts = await this.alertsRepo.find({ where: { triggered: false } });
+
+    for (const alert of activeAlerts) {
       const currentRate = rates[alert.currencyPair];
       if (!currentRate) continue;
 
@@ -45,7 +37,7 @@ export class RateAlertsService {
         : currentRate <= alert.targetRate;
 
       if (breached) {
-        alert.triggered = true;
+        await this.alertsRepo.update({ id: alert.id }, { triggered: true });
         this.events.emit('rate-alert.triggered', { alertId: alert.id, userId: alert.userId, currencyPair: alert.currencyPair, rate: currentRate });
         this.logger.log(`Rate alert ${alert.id} triggered for ${alert.currencyPair} at ${currentRate}`);
       }

--- a/src/transactions/transaction-limit.service.ts
+++ b/src/transactions/transaction-limit.service.ts
@@ -10,6 +10,9 @@ const SINGLE_TX_LIMIT_USD = parseFloat(process.env.SINGLE_TX_LIMIT_USD ?? '25000
 const dailyTotals = new Map<string, number>();
 const monthlyTotals = new Map<string, number>();
 
+/** Per-user lock chain so check-and-increment is atomic within this instance. */
+const userLocks = new Map<string, Promise<unknown>>();
+
 @Injectable()
 export class TransactionLimitService {
   private readonly logger = new Logger(TransactionLimitService.name);
@@ -29,10 +32,23 @@ export class TransactionLimitService {
       );
     }
 
-    const today = this.dateKey();
-    const month = this.monthKey();
-    const dayKey = `${userId}:${today}`;
-    const monKey = `${userId}:${month}`;
+    // Chain onto any in-flight check for this user so the read-check-write
+    // below is never interleaved with a concurrent call for the same user.
+    const previous = userLocks.get(userId) ?? Promise.resolve();
+    const current = previous
+      .catch(() => undefined)
+      .then(() => this.checkAndCommit(userId, amountUsd));
+    userLocks.set(userId, current);
+    try {
+      await current;
+    } finally {
+      if (userLocks.get(userId) === current) userLocks.delete(userId);
+    }
+  }
+
+  private checkAndCommit(userId: string, amountUsd: number): void {
+    const dayKey = `${userId}:${this.dateKey()}`;
+    const monKey = `${userId}:${this.monthKey()}`;
 
     const dayTotal = (dailyTotals.get(dayKey) ?? 0) + amountUsd;
     const monTotal = (monthlyTotals.get(monKey) ?? 0) + amountUsd;


### PR DESCRIPTION
Closes #1069
Closes #1070
Closes #1071
Closes #1072

- **#1069** — `refreshExpiredRates` now counts rows with `expiresAt <= now` (was `MoreThan`, which counted still-valid pairs) and refreshes whenever any pair is expired instead of requiring all pairs to expire simultaneously.
- **#1070** — `TransactionLimitService.check` now serializes the read-check-write per user via a lock-chain, closing the check-then-set race within a single instance. (Note: full cross-instance persistence would need a DB/Redis-backed counter, out of scope for this minimal fix.)
- **#1071** — `WithdrawalController` now delegates to the real, working `TransactionsService.createWithdrawal()` instead of returning a fabricated success response with no balance change.
- **#1072** — `RateAlertsService` now reads/writes `RateAlertEntity` via `Repository` instead of an in-memory array, so alerts persist and account-deletion's cleanup of `rate_alerts` has real rows to remove. (Note: wiring a cron to call `checkThresholds` with live rates is a follow-up outside this single-file change.)