### PR TITLE
Fix transaction table collision, rollback race, fee-rate parity, and fee-tier amount filtering

### DIFF
--- a/src/fee-tiers/fee-tiers.service.ts
+++ b/src/fee-tiers/fee-tiers.service.ts
@@ -21,13 +21,14 @@ export class FeeTiersService {
   }
 
   async findByKycLevelAndAmount(kycLevel: KycFeeLevel, currency: string, amount: number): Promise<FeeTierEntity | null> {
-    return this.feeTierRepo.findOne({
-      where: {
-        kycLevel,
-        currency,
-        isActive: true,
-      },
-    });
+    return this.feeTierRepo
+      .createQueryBuilder('t')
+      .where('t.kycLevel = :kycLevel', { kycLevel })
+      .andWhere('t.currency = :currency', { currency })
+      .andWhere('t.isActive = true')
+      .andWhere('t.tierMin <= :amount', { amount })
+      .andWhere('t.tierMax >= :amount', { amount })
+      .getOne();
   }
 
   async calculateFee(kycLevel: KycFeeLevel, currency: string, amount: number): Promise<{ tier: FeeTierEntity | null; feeAmount: number; totalAmount: number }> {

--- a/src/fees/fees.service.ts
+++ b/src/fees/fees.service.ts
@@ -19,7 +19,8 @@ export interface RecordFeeDto {
   reason?: string | null;
 }
 
-const FEE_RATE = 0.001; // 0.1% flat fee
+const DEFAULT_FEE_RATE = 0.001; // 0.1% flat fee
+const WITHDRAWAL_FEE_RATE = 0.005; // 0.5% flat fee
 
 @Injectable()
 export class FeesService {
@@ -31,12 +32,16 @@ export class FeesService {
     private readonly feeAuditService: FeeAuditService,
   ) {}
 
-  calculateFee(amount: number): FeeResult {
-    const feeAmount = Number((amount * FEE_RATE).toFixed(8));
+  private getFeeRate(transactionType: string): number {
+    return transactionType === 'withdrawal' ? WITHDRAWAL_FEE_RATE : DEFAULT_FEE_RATE;
+  }
+
+  calculateFee(amount: number, transactionType = 'default', currency = 'USD'): FeeResult {
+    const feeAmount = Number((amount * this.getFeeRate(transactionType)).toFixed(8));
 
     this.feeAuditService.recordFeeCalculation({
       feeAmount,
-      currency: 'USD',
+      currency,
       feeType: 'percentage',
       calculatedAmount: amount,
       appliedTier: 'flat',
@@ -46,7 +51,7 @@ export class FeesService {
   }
 
   previewFee(transactionType: string, amount: number, currency = 'USD') {
-    const feeRate = transactionType === 'withdrawal' ? 0.005 : 0.001;
+    const feeRate = this.getFeeRate(transactionType);
     const feeAmount = Number((amount * feeRate).toFixed(8));
     const netAmount = Number((amount - feeAmount).toFixed(8));
     return {

--- a/src/modules/transactions/entities/transaction-rollback.entity.ts
+++ b/src/modules/transactions/entities/transaction-rollback.entity.ts
@@ -7,12 +7,12 @@ import {
 } from 'typeorm';
 
 @Entity('transaction_rollbacks')
-@Index('idx_transaction_rollbacks_original', ['originalTransactionId'])
+@Index('idx_transaction_rollbacks_original', ['originalTransactionId'], { unique: true })
 export class TransactionRollbackEntity {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'uuid' })
+  @Column({ type: 'uuid', unique: true })
   originalTransactionId: string;
 
   @Column({ type: 'uuid' })

--- a/src/modules/transactions/entities/transaction.entity.ts
+++ b/src/modules/transactions/entities/transaction.entity.ts
@@ -11,7 +11,7 @@ import {
 } from 'typeorm';
 import { TransactionCategoryEntity } from './transaction-category.entity';
 
-@Entity('transactions')
+@Entity('wallet_transactions')
 @Index('idx_transactions_status', ['status'])
 @Index('idx_transactions_created_at', ['createdAt'])
 @Index('idx_transactions_search_vector', ['searchVector'], { fulltext: true })


### PR DESCRIPTION
Closes #1065
Closes #1066
Closes #1067
Closes #1068

- **#1065**: Renamed `TransactionEntity`'s table from `transactions` to `wallet_transactions` so it no longer collides with the `Transaction` entity's physical table.
- **#1066**: Added a unique constraint on `TransactionRollbackEntity.originalTransactionId` so the database rejects a second rollback row for the same transaction.
- **#1067**: `FeesService.calculateFee` now shares the same rate table as `previewFee` and records the transaction's real currency in the fee audit instead of a hardcoded `'USD'`.
- **#1068**: `FeeTiersService.findByKycLevelAndAmount` now filters by `tierMin`/`tierMax` against the given amount, matching `calculateFee`.