### PR TITLE
Fix wallet/reconciliation/ledger balance-integrity bugs (Wave 200pts batch)

### DIFF
--- a/src/fx/fx.service.ts
+++ b/src/fx/fx.service.ts
@@ -36,8 +36,8 @@ export class FxService {
     const toAmount = parseFloat((dto.fromAmount * rate).toFixed(8));
 
     return this.dataSource.transaction(async (manager) => {
-      this.wallets.adjustBalance(dto.userId, dto.fromCurrency, -dto.fromAmount);
-      this.wallets.adjustBalance(dto.userId, dto.toCurrency, toAmount);
+      await this.wallets.adjustBalance(dto.userId, dto.fromCurrency, -dto.fromAmount);
+      await this.wallets.adjustBalance(dto.userId, dto.toCurrency, toAmount);
 
       const trade = manager.create(FxTrade, {
         userId: dto.userId,
@@ -71,8 +71,8 @@ export class FxService {
     }
 
     return this.dataSource.transaction(async (manager) => {
-      this.wallets.adjustBalance(trade.userId, trade.fromCurrency, trade.fromAmount);
-      this.wallets.adjustBalance(trade.userId, trade.toCurrency, -trade.toAmount);
+      await this.wallets.adjustBalance(trade.userId, trade.fromCurrency, trade.fromAmount);
+      await this.wallets.adjustBalance(trade.userId, trade.toCurrency, -trade.toAmount);
 
       trade.reversedAt = new Date();
       return manager.save(FxTrade, trade);

--- a/src/reconciliation/reconciliation.service.ts
+++ b/src/reconciliation/reconciliation.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { Cron } from '@nestjs/schedule';
 import Big from 'big.js';
 import { Transaction, TransactionStatus } from '../transactions/transaction.entity';
@@ -17,6 +17,8 @@ export class ReconciliationService {
     private readonly txRepo: Repository<Transaction>,
     @InjectRepository(WalletBalanceEntity)
     private readonly walletRepo: Repository<WalletBalanceEntity>,
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
   ) {}
 
   @Cron('0 2 * * *')
@@ -38,8 +40,18 @@ export class ReconciliationService {
       ],
     });
 
+    // Archived transactions are deleted from the live table, but the wallet
+    // balance still reflects the money they moved — union them back in.
+    const archivedTxs = await this.dataSource
+      .query(
+        `SELECT "senderId", "receiverId", amount, fee, metadata FROM "transactions_archive"
+         WHERE ("receiverId" = $1 OR "senderId" = $1) AND currency = $2 AND status = $3`,
+        [accountId, currency, TransactionStatus.COMPLETED],
+      )
+      .catch(() => []);
+
     let ledgerBalance = new Big('0');
-    for (const tx of txs) {
+    for (const tx of [...txs, ...archivedTxs]) {
       const amount = new Big(String(tx.amount));
       const fee = new Big(String(tx.fee ?? 0));
       const type = (tx.metadata as { type?: string } | null)?.type;

--- a/src/reconciliation/reconciliation.service.ts
+++ b/src/reconciliation/reconciliation.service.ts
@@ -31,15 +31,31 @@ export class ReconciliationService {
     const wallet = await this.walletRepo.findOneBy({ accountId, currency });
     if (!wallet) return;
 
-    const result = await this.txRepo
-      .createQueryBuilder('tx')
-      .select('SUM(tx.amount)', 'total')
-      .where('tx.receiverId = :id AND tx.currency = :currency AND tx.status = :status', {
-        id: accountId, currency, status: TransactionStatus.COMPLETED,
-      })
-      .getRawOne<{ total: string }>();
+    const txs = await this.txRepo.find({
+      where: [
+        { receiverId: accountId, currency, status: TransactionStatus.COMPLETED },
+        { senderId: accountId, currency, status: TransactionStatus.COMPLETED },
+      ],
+    });
 
-    const ledgerBalance = new Big(result?.total ?? '0');
+    let ledgerBalance = new Big('0');
+    for (const tx of txs) {
+      const amount = new Big(String(tx.amount));
+      const fee = new Big(String(tx.fee ?? 0));
+      const type = (tx.metadata as { type?: string } | null)?.type;
+
+      if (tx.receiverId === accountId && type === 'withdrawal') {
+        // self-referencing withdrawal row: money leaves the account
+        ledgerBalance = ledgerBalance.minus(amount).minus(fee);
+      } else if (tx.receiverId === accountId) {
+        // deposit or incoming transfer: money enters the account
+        ledgerBalance = ledgerBalance.plus(amount);
+      } else if (tx.senderId === accountId) {
+        // outgoing transfer: sender-side debit, previously never subtracted
+        ledgerBalance = ledgerBalance.minus(amount).minus(fee);
+      }
+    }
+
     const diff = ledgerBalance.minus(new Big(String(wallet.balance))).abs();
 
     if (diff.gt(TOLERANCE)) {

--- a/src/wallet/wallets.module.ts
+++ b/src/wallet/wallets.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { WalletBalanceEntity } from './wallet-balance.entity';
 import { WalletsController } from './wallets.controller';
 import { WalletsService } from './wallets.service';
+import { LedgerModule } from '../ledger/ledger.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([WalletBalanceEntity])],
+  imports: [TypeOrmModule.forFeature([WalletBalanceEntity]), LedgerModule],
   controllers: [WalletsController],
   providers: [WalletsService],
   exports: [WalletsService],

--- a/src/wallet/wallets.service.ts
+++ b/src/wallet/wallets.service.ts
@@ -9,6 +9,8 @@ import {
 } from '../currencies/supported-currencies';
 import { WalletBalanceEntity } from './wallet-balance.entity';
 import { WalletBalance } from './wallets.types';
+import { LedgerService } from '../ledger/ledger.service';
+import { LedgerEntryType } from '../ledger/ledger-entry.entity';
 
 @Injectable()
 export class WalletsService {
@@ -16,6 +18,7 @@ export class WalletsService {
     @InjectRepository(WalletBalanceEntity)
     private readonly walletRepository: Repository<WalletBalanceEntity>,
     private readonly dataSource: DataSource,
+    private readonly ledgerService: LedgerService,
   ) {}
 
   async adjustBalance(
@@ -50,6 +53,14 @@ export class WalletsService {
 
       wallet.balance = newBalance;
       const saved = await manager.save(wallet);
+
+      await this.ledgerService.recordEntry({
+        userId: accountId,
+        type: delta > 0 ? LedgerEntryType.CREDIT : LedgerEntryType.DEBIT,
+        amount: Math.abs(delta),
+        currency: normalizedCurrency,
+        balanceAfter: newBalance,
+      });
 
       return {
         id: saved.id,


### PR DESCRIPTION
Closes #1061
Closes #1062
Closes #1063
Closes #1064

- **#1061**: `FxService.executeTrade`/`reverseTrade` now `await` all `adjustBalance` calls instead of firing them without awaiting, so a failed balance adjustment properly rejects instead of silently persisting a trade.
- **#1062**: `ReconciliationService.reconcileAccount` now computes a signed balance (credits vs. withdrawals/outgoing transfers with fees subtracted) instead of blindly summing every row where the account is `receiverId`.
- **#1063**: Reconciliation now unions in rows from `transactions_archive` so archiving old transactions no longer produces a permanent false discrepancy.
- **#1064**: `WalletsService.adjustBalance` now calls `LedgerService.recordEntry` on every balance change, so the ledger module actually records entries instead of being dead code.