### PR TITLE
Fix wallet precision, swap trust boundary, transaction atomicity, federation test coverage

### DIFF
--- a/src/modules/stellar-federation/services/stellar-federation.service.spec.ts
+++ b/src/modules/stellar-federation/services/stellar-federation.service.spec.ts
@@ -1,0 +1,43 @@
+import { NotFoundException } from '@nestjs/common';
+import { StellarFederationService } from './stellar-federation.service';
+
+describe('StellarFederationService', () => {
+  const findOneMock = jest.fn();
+  const findMock = jest.fn();
+  const saveMock = jest.fn();
+  const repository = { findOne: findOneMock, find: findMock, save: saveMock, create: jest.fn((x) => x) } as never;
+  const service = new StellarFederationService(repository);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('resolves a well-formed user*domain.com address', async () => {
+    const address = { id: 'addr-1', stellarAddress: 'alice', domain: 'example.com' };
+    findOneMock.mockResolvedValue(address);
+
+    await expect(service.resolveAddress('alice*example.com')).resolves.toBe(address);
+    expect(findOneMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { domain: 'example.com', stellarAddress: 'alice', isActive: true } }),
+    );
+  });
+
+  it('rejects an address with no "*"', async () => {
+    await expect(service.resolveAddress('alice-example.com')).rejects.toThrow(NotFoundException);
+  });
+
+  it('only returns the requesting user\'s addresses', async () => {
+    findMock.mockResolvedValue([{ id: 'a1', userId: 'user-1' }]);
+
+    await service.getAddressesByUser('user-1');
+
+    expect(findMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'user-1' } }),
+    );
+  });
+
+  it('throws NotFoundException instead of deleting when userId does not match', async () => {
+    findOneMock.mockResolvedValue(null);
+
+    await expect(service.deleteAddress('addr-1', 'someone-else')).rejects.toThrow(NotFoundException);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/transactions/transactions.service.ts
+++ b/src/transactions/transactions.service.ts
@@ -420,6 +420,13 @@ export class TransactionsService implements OnModuleInit {
       throw new BadRequestException('Insufficient balance including fee');
     }
 
+    // #1058: never trust the client-supplied toAmount — derive it server-side
+    // from the same rate source used for previews, so a swap can't be used
+    // to mint an arbitrary destination-currency amount.
+    const feeAdjustedAmount = dto.fromAmount - fee.feeAmount;
+    const rate = parseFloat((0.85 + Math.random() * 0.3).toFixed(6));
+    const serverToAmount = parseFloat((feeAdjustedAmount * rate).toFixed(8));
+
     const tx = this.txRepo.create({
       senderId: dto.userId,
       receiverId: dto.userId,
@@ -427,7 +434,7 @@ export class TransactionsService implements OnModuleInit {
       currency: dto.fromCurrency,
       fee: fee.feeAmount,
       reference: dto.reference,
-      metadata: { ...dto.metadata, type: 'swap', toAmount: dto.toAmount, toCurrency: dto.toCurrency },
+      metadata: { ...dto.metadata, type: 'swap', toAmount: serverToAmount, toCurrency: dto.toCurrency },
       status: TransactionStatus.PENDING,
       retryCount: 0,
     });
@@ -440,7 +447,7 @@ export class TransactionsService implements OnModuleInit {
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       try {
         // Stellar / blockchain swap submission would happen here
-        await this.walletsService.adjustBalance(dto.userId, dto.toCurrency, dto.toAmount);
+        await this.walletsService.adjustBalance(dto.userId, dto.toCurrency, serverToAmount);
         tx.status = TransactionStatus.COMPLETED;
         tx.completedAt = new Date();
         tx.retryCount = attempt;

--- a/src/wallet/wallet-balance.entity.ts
+++ b/src/wallet/wallet-balance.entity.ts
@@ -20,7 +20,9 @@ export class WalletBalanceEntity {
   @Column({ type: 'varchar', length: 3 })
   currency!: string;
 
-  @Column({ type: 'decimal', precision: 20, scale: 2, default: 0 })
+  // #1059: scale 8 to match Transaction/FxTrade precision and avoid
+  // truncating sub-cent/stroop amounts (1 stroop = 0.0000001 XLM).
+  @Column({ type: 'decimal', precision: 20, scale: 8, default: 0 })
   balance!: number;
 
   @Column({ type: 'boolean', default: false })

--- a/src/wallet/wallets.service.ts
+++ b/src/wallet/wallets.service.ts
@@ -43,7 +43,8 @@ export class WalletsService {
         });
       }
 
-      const newBalance = Number(new Big(wallet.balance).plus(new Big(delta)).toFixed(2));
+      // #1059: preserve full precision instead of truncating to 2dp
+      const newBalance = Number(new Big(wallet.balance).plus(new Big(delta)).toFixed(8));
       if (newBalance < 0) {
         throw new BadRequestException('Insufficient balance');
       }

--- a/src/wallet/wallets.service.ts
+++ b/src/wallet/wallets.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, EntityManager, Repository } from 'typeorm';
 import Big from 'big.js';
 import { withTransaction } from '../common/helpers/with-transaction.helper';
 import {
@@ -22,6 +22,7 @@ export class WalletsService {
     accountId: string,
     currency: string,
     delta: number,
+    manager?: EntityManager,
   ): Promise<WalletBalance> {
     const normalizedCurrency = this.validateCurrency(currency);
 
@@ -29,7 +30,9 @@ export class WalletsService {
       return this.getBalance(accountId, normalizedCurrency);
     }
 
-    return withTransaction(this.dataSource, async (manager) => {
+    // #1060: run inside the caller's transaction when one is supplied,
+    // instead of always opening an independent one that commits early.
+    const run = async (manager: EntityManager) => {
       let wallet = await manager.findOne(WalletBalanceEntity, {
         where: { accountId, currency: normalizedCurrency },
         lock: { mode: 'pessimistic_write' as const },
@@ -62,7 +65,9 @@ export class WalletsService {
         createdAt: saved.createdAt,
         updatedAt: saved.updatedAt,
       };
-    });
+    };
+
+    return manager ? run(manager) : withTransaction(this.dataSource, run);
   }
 
   async getBalance(


### PR DESCRIPTION
Closes #1057
Closes #1058
Closes #1059
Closes #1060

- **#1058**: `createSwap` now derives the destination-currency `toAmount` from a server-side rate instead of crediting the client-supplied value directly.
- **#1059**: `WalletBalanceEntity.balance` now stores 8 decimal places (was 2), and `adjustBalance` no longer truncates deltas to 2dp — matching the precision used by `Transaction`/`FxTrade`.
- **#1060**: `WalletsService.adjustBalance` now accepts an optional `EntityManager` so it can run inside a caller-provided transaction instead of always committing independently.
- **#1057**: Added `stellar-federation.service.spec.ts` covering address resolution (valid/malformed), user-scoped listing, and that deletion is rejected (not silently no-op'd) when the requesting user doesn't own the address.