### PR TITLE
Fix wallet-history N+1, batch-processor fake success, idempotency compile defects, transfer idempotency

### DIFF
--- a/src/idempotency/idempotency.guard.ts
+++ b/src/idempotency/idempotency.guard.ts
@@ -8,9 +8,6 @@ import {
 import { Reflector } from '@nestjs/core';
 import { IdempotencyService } from './idempotency.service';
 import { IDEMPOTENCY_KEY } from './idempotency.decorator';
-
-export const MIN_KEY_LENGTH = 16;
-export const MAX_KEY_LENGTH = 255;
 import { MAX_KEY_LENGTH, MIN_KEY_LENGTH } from './constants';
 
 @Injectable()

--- a/src/modules/wallet-history/services/wallet-history.service.ts
+++ b/src/modules/wallet-history/services/wallet-history.service.ts
@@ -25,23 +25,28 @@ export class WalletHistoryService {
     const balances: Record<string, number> = {};
     let totalValueUsd = 0;
 
-    for (const wallet of wallets) {
-      const transactions = await this.txRepo.find({
-        where: { walletId: wallet.id },
-      });
+    if (wallets.length > 0) {
+      // Single grouped aggregate instead of one find() per wallet + JS summation (was O(n) per snapshot).
+      const sums = await this.txRepo
+        .createQueryBuilder('tx')
+        .select('tx.walletId', 'walletId')
+        .addSelect(
+          `SUM(CASE WHEN tx.metadata->>'type' = 'CREDIT' OR tx.fromAddress IS NULL THEN tx.amount ELSE -tx.amount END)`,
+          'balance',
+        )
+        .where('tx.walletId IN (:...walletIds)', { walletIds: wallets.map((w) => w.id) })
+        .andWhere('tx.status = :status', { status: 'SUCCESS' })
+        .groupBy('tx.walletId')
+        .getRawMany<{ walletId: string; balance: string }>();
 
-      let balance = 0;
-      for (const tx of transactions) {
-        const amount = Number(tx.amount);
-        const isCredit = tx.metadata?.type === 'CREDIT' || tx.fromAddress == null;
-        if (tx.status === 'SUCCESS') {
-          balance += isCredit ? amount : -amount;
+      const balanceByWallet = new Map(sums.map((s) => [s.walletId, Number(s.balance) || 0]));
+
+      for (const wallet of wallets) {
+        const balance = balanceByWallet.get(wallet.id) ?? 0;
+        balances[wallet.currency] = (balances[wallet.currency] ?? 0) + balance;
+        if (wallet.currency === 'USD') {
+          totalValueUsd += balance;
         }
-      }
-
-      balances[wallet.currency] = (balances[wallet.currency] ?? 0) + balance;
-      if (wallet.currency === 'USD') {
-        totalValueUsd += balance;
       }
     }
 

--- a/src/transaction/batch-processor.service.ts
+++ b/src/transaction/batch-processor.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotImplementedException } from '@nestjs/common';
 
 export interface BatchTransactionItem {
   recipientAddress: string;
@@ -16,7 +16,9 @@ export interface BatchProcessingResult {
 
 /**
  * Transaction Batch Processing Service
- * Enables businesses to process multiple payments in a single API call
+ * @deprecated Not registered in any module and not wired to real transaction
+ * submission — `submitSingleTransaction`/`getBatchStatus` are unfinished
+ * placeholders. Do not use until a real implementation lands (#1074).
  */
 @Injectable()
 export class BatchProcessorService {
@@ -58,10 +60,10 @@ export class BatchProcessorService {
    * @returns Current status of the batch
    */
   async getBatchStatus(batchId: string): Promise<any> {
-    return { batchId, status: 'completed' };
+    throw new NotImplementedException('Batch status tracking is not implemented; no batch state is persisted.');
   }
 
   private async submitSingleTransaction(from: string, item: BatchTransactionItem): Promise<string> {
-    return 'tx_hash_placeholder';
+    throw new NotImplementedException('Batch transaction submission is not implemented.');
   }
 }

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -54,6 +54,9 @@ export class TransactionsController {
 
   @Post('transfer')
   @HttpCode(HttpStatus.CREATED)
+  @Idempotent()
+  @UseGuards(IdempotencyGuard)
+  @UseInterceptors(IdempotencyInterceptor)
   transfer(@Body() dto: TransferDto) {
     return this.txService.transfer(dto);
   }

--- a/src/transactions/transactions.controller.ts
+++ b/src/transactions/transactions.controller.ts
@@ -11,9 +11,9 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
-  UseGuards,
   UseInterceptors,
   Sse,
+  Req,
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
@@ -226,10 +226,5 @@ export class TransactionsController {
     @Body() body: { authorId: string; text: string },
   ) {
     return this.txService.addComment(id, body.authorId, body.text);
-  }
-
-  @Get(':id/comments')
-  getComments(@Param('id') id: string) {
-    return this.txService.getComments(id);
   }
 }


### PR DESCRIPTION
Closes #1073
Closes #1074
Closes #1075
Closes #1076

- #1073: `WalletHistoryService.recordSnapshot` replaced the per-wallet `find()` + JS summation loop with a single grouped aggregate query (`SUM(...) GROUP BY walletId`), bounding query count regardless of transaction history length.
- #1074: `BatchProcessorService.submitSingleTransaction`/`getBatchStatus` no longer report fake success — they throw `NotImplementedException` and the class is marked `@deprecated` until a real implementation lands.
- #1075: Removed the duplicate local `MIN_KEY_LENGTH`/`MAX_KEY_LENGTH` declarations in `idempotency.guard.ts` (now solely imported from `./constants`), de-duplicated the `UseGuards` import and the duplicate `getComments` route in `transactions.controller.ts`, and added the missing `Req` import used by `updateTags`.
- #1076: Added `@Idempotent()`, `@UseGuards(IdempotencyGuard)`, and `@UseInterceptors(IdempotencyInterceptor)` to the `transfer` handler, matching `deposit`/`withdrawal`/`swap`.