### PR TITLE
fix(docker,security,health,lint): container healthchecks, IpAllowlistGuard fail-closed, install lint-staged, comprehensive health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,5 @@ RUN npm ci --only=production
 USER app
 
 EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 CMD wget -qO- http://localhost:3000/health || exit 1
 CMD ["node", "dist/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,11 @@ services:
       - '6379:6379'
     volumes:
       - redis-data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   app:
     build: .
@@ -32,7 +37,12 @@ services:
       db:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:3000/health || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 3
     environment:
       - DB_HOST=db
       - DB_PORT=5432

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.0.0",
     "jest": "^29.7.0",
+    "lint-staged": "^15.2.0",
     "prettier": "^3.4.2",
     "socket.io-client": "^4.8.3",
     "source-map-support": "^0.5.21",

--- a/src/common/guards/ip-allowlist.guard.spec.ts
+++ b/src/common/guards/ip-allowlist.guard.spec.ts
@@ -12,7 +12,7 @@ describe('IpAllowlistGuard', () => {
     jest.clearAllMocks();
   });
 
-  it('allows requests when the allowlist is not configured', () => {
+  it('denies requests when the allowlist is not configured', () => {
     (config.get as jest.Mock).mockReturnValue([]);
     const context = {
       switchToHttp: () => ({
@@ -20,7 +20,9 @@ describe('IpAllowlistGuard', () => {
       }),
     } as unknown as ExecutionContext;
 
-    expect(guard.canActivate(context)).toBe(true);
+    expect(() => guard.canActivate(context)).toThrow(
+      'ADMIN_ALLOWED_IPS is not configured; admin access denied',
+    );
   });
 
   it('blocks requests outside allowlisted cidrs', () => {

--- a/src/common/guards/ip-allowlist.guard.ts
+++ b/src/common/guards/ip-allowlist.guard.ts
@@ -79,9 +79,11 @@ export class IpAllowlistGuard implements CanActivate {
 
     if (allowedIps.length === 0) {
       this.logger.warn(
-        'ADMIN_ALLOWED_IPS is not configured; allowing admin requests from any IP',
+        'ADMIN_ALLOWED_IPS is not configured; denying admin requests',
       );
-      return true;
+      throw new ForbiddenException(
+        'ADMIN_ALLOWED_IPS is not configured; admin access denied',
+      );
     }
 
     const request = context.switchToHttp().getRequest<Request>();

--- a/src/health/health.service.ts
+++ b/src/health/health.service.ts
@@ -1,18 +1,38 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
+import { DataSource } from 'typeorm';
 import { firstValueFrom } from 'rxjs';
 
 @Injectable()
 export class HealthService {
-  constructor(private readonly http: HttpService) {}
+  constructor(
+    private readonly http: HttpService,
+    @Optional() private readonly dataSource?: DataSource,
+  ) {}
 
   async check(): Promise<Record<string, string>> {
     const stellarUrl = process.env.STELLAR_HORIZON_URL || 'https://horizon.stellar.org';
+    let stellarStatus = 'connected';
     try {
       await firstValueFrom(this.http.get(stellarUrl));
-      return { status: 'healthy', stellar: 'connected' };
     } catch {
-      return { status: 'unhealthy', stellar: 'disconnected' };
+      stellarStatus = 'disconnected';
     }
+
+    let dbStatus = 'connected';
+    if (this.dataSource) {
+      try {
+        await this.dataSource.query('SELECT 1');
+      } catch {
+        dbStatus = 'disconnected';
+      }
+    }
+
+    const isHealthy = stellarStatus === 'connected' && dbStatus === 'connected';
+    return {
+      status: isHealthy ? 'healthy' : 'unhealthy',
+      stellar: stellarStatus,
+      database: dbStatus,
+    };
   }
 }


### PR DESCRIPTION
Adds container healthchecks to Dockerfile and docker-compose, updates IpAllowlistGuard to fail closed when ADMIN_ALLOWED_IPS is empty/unset, adds lint-staged dev dependency, and enhances health service to check database and Horizon connectivity.

Closes #1085
Closes #1086
Closes #1087
Closes #1088