### PR TITLE
fix(docker,auth,env,metrics): install ts-node in Docker, GraphQL-aware JwtAuthGuard, fix duplicate Zod env key, bound metrics interceptor cardinality

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.3",
     "typeorm": "^0.3.28",
+    "ts-node": "^10.9.2",
     "uuid": "^9.0.1",
     "zod": "^4.3.6"
   },
@@ -118,7 +119,6 @@
     "supertest": "^7.0.0",
     "ts-jest": "^29.4.6",
     "ts-loader": "^9.5.2",
-    "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -31,6 +31,22 @@ export class JwtAuthGuard implements CanActivate {
     private readonly reflector: Reflector,
   ) {}
 
+  private getRequest(context: ExecutionContext): AuthenticatedRequest {
+    if ((context.getType() as string) === 'graphql') {
+      try {
+        const { GqlExecutionContext } = require('@nestjs/graphql');
+        const gqlContext = GqlExecutionContext.create(context);
+        return gqlContext.getContext().req;
+      } catch {
+        const args = context.getArgs();
+        return (
+          args[2]?.req || context.switchToHttp().getRequest<AuthenticatedRequest>()
+        );
+      }
+    }
+    return context.switchToHttp().getRequest<AuthenticatedRequest>();
+  }
+
   canActivate(context: ExecutionContext): boolean {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
@@ -41,7 +57,7 @@ export class JwtAuthGuard implements CanActivate {
       return true;
     }
 
-    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const request = this.getRequest(context);
     const authorization = request.headers.authorization;
     const bearerToken = Array.isArray(authorization)
       ? authorization[0]

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -393,11 +393,6 @@ export const envSchema = z.object({
   // Stellar Hot Wallet (required — fail-fast on startup)
   // ============================================
   STELLAR_HOT_WALLET_SECRET: z.string().min(1, 'STELLAR_HOT_WALLET_SECRET is required'),
-  WALLET_BALANCE_CACHE_TTL_SECONDS: z
-    .string()
-    .transform(Number)
-    .pipe(z.number().int().positive())
-    .default(() => 30),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/metrics/metrics.interceptor.ts
+++ b/src/metrics/metrics.interceptor.ts
@@ -17,9 +17,14 @@ export class MetricsInterceptor implements NestInterceptor {
     const http = context.switchToHttp();
     const req = http.getRequest<Request>();
     const res = http.getResponse<Response>();
-    const method = req.method;
-    const route =
-      (req.route?.path as string | undefined) ?? req.path ?? 'unknown';
+    let route = 'unmatched';
+    if (req.route?.path) {
+      route = String(req.route.path);
+    } else if (req.path) {
+      route = req.path
+        .replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '/:id')
+        .replace(/\/\d+/g, '/:id');
+    }
 
     return next.handle().pipe(
       tap({


### PR DESCRIPTION
Ensures ts-node is included in production dependencies for Docker migrations/seeds, makes JwtAuthGuard aware of GraphQL execution contexts, removes duplicate WALLET_BALANCE_CACHE_TTL_SECONDS definition in env validation schema, and normalizes route paths in MetricsInterceptor to prevent unbounded label cardinality.

Closes #1089
Closes #1090
Closes #1091
Closes #1092