### PR TITLE
test(documents,reports): register S3Service and FeeRevenueController, reorganize feature specs, add missing unit coverage

### DIFF
--- a/src/admin/abdulrcrtw-features.spec.ts
+++ b/src/admin/abdulrcrtw-features.spec.ts
@@ -1,6 +1,6 @@
-import { AdminService } from './admin/admin.service';
-import { ExchangeRatesService } from './exchange-rates/exchange-rates.service';
-import { MailService } from './mail/mail.service';
+import { AdminService } from '../admin/admin.service';
+import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
+import { MailService } from '../mail/mail.service';
 
 describe('abdulrcrtw Features (Issues #992, #991, #990, #989)', () => {
   it('AdminService supports spread configuration management and audit logging', async () => {

--- a/src/admin/kike-alt-features.spec.ts
+++ b/src/admin/kike-alt-features.spec.ts
@@ -1,7 +1,7 @@
-import { AdminService } from './admin/admin.service';
-import { AdminAlertService } from './admin/admin-alert.service';
-import { CurrenciesService } from './currencies/currencies.service';
-import { UsersService } from './users/users.service';
+import { AdminService } from '../admin/admin.service';
+import { AdminAlertService } from '../admin/admin-alert.service';
+import { CurrenciesService } from '../currencies/currencies.service';
+import { UsersService } from '../users/users.service';
 
 describe('kike-alt Features (Issues #980, #979, #978, #977)', () => {
   it('AdminService performs platform-wide search across users and transactions', async () => {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -95,6 +95,7 @@ import { FeeAuditModule } from './modules/fee-audit/fee-audit.module';
 import { ActivityFeedModule } from './activity-feed/activity-feed.module';
 import { NotificationPreferencesModule } from './notification-preferences/notification-preferences.module';
 import { ReferralModule } from './referral/referral.module';
+import { FeeRevenueModule } from './reports/fee-revenue.module';
 import { AmlModule } from './aml/aml.module';
 import { EscrowModule } from './modules/escrow/escrow.module';
 import { SplitPaymentsModule } from './modules/split-payments/split-payments.module';
@@ -298,6 +299,7 @@ async function createCacheOptions(configService: ConfigService<Configuration>) {
     ActivityFeedModule,
     NotificationPreferencesModule,
     ReferralModule,
+    FeeRevenueModule,
     AmlModule,
     ModulesWalletsModule,
     ModulesCacheModule,

--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { DocumentsController } from './documents.controller';
 import { PdfService } from './pdf.service';
+import { S3Service } from './s3.service';
 
 @Module({
   controllers: [DocumentsController],
-  providers: [PdfService],
+  providers: [PdfService, S3Service],
 })
 export class DocumentsModule {}

--- a/src/kyc/mxllv-features.spec.ts
+++ b/src/kyc/mxllv-features.spec.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { KycService } from '../src/kyc/kyc.service';
-import { FxService } from '../src/fx/fx.service';
-import { FeesService } from '../src/fees/fees.service';
-import { AuthService } from '../src/auth/auth.service';
+import { KycService } from './kyc.service';
+import { FxService } from '../fx/fx.service';
+import { FeesService } from '../fees/fees.service';
+import { AuthService } from '../auth/auth.service';
 
 describe('mxllv Features (Issues #919, #918, #915, #912)', () => {
   it('KYC expiry check correctly identifies active vs expired approval', async () => {

--- a/src/reports/fee-revenue.module.ts
+++ b/src/reports/fee-revenue.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { FeeRevenueController } from './fee-revenue.controller';
+
+@Module({
+  controllers: [FeeRevenueController],
+})
+export class FeeRevenueModule {}

--- a/src/scheduled-reports/scheduled-reports.service.spec.ts
+++ b/src/scheduled-reports/scheduled-reports.service.spec.ts
@@ -1,0 +1,102 @@
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { NotificationPreferencesService } from '../notification-preferences/notification-preferences.service';
+import {
+  NotificationChannel,
+  NotificationEventType,
+} from '../notification-preferences/notification-preference.entity';
+import {
+  ScheduledReportsService,
+} from './scheduled-reports.service';
+import { ReportType, ReportFrequency } from './entities/scheduled-report.entity';
+import { TermsController } from '../terms/terms.controller';
+
+describe('NotificationPreferencesService', () => {
+  it('returns true when no preference row exists', async () => {
+    const repo = { findOne: jest.fn().mockResolvedValue(null) };
+    const service = new NotificationPreferencesService(repo as any);
+    await expect(
+      service.shouldNotify('u1', NotificationChannel.EMAIL, NotificationEventType.SECURITY),
+    ).resolves.toBe(true);
+  });
+
+  it('honors an explicit isEnabled flag', async () => {
+    const repo = {
+      findOne: jest
+        .fn()
+        .mockResolvedValue({ isEnabled: false }),
+    };
+    const service = new NotificationPreferencesService(repo as any);
+    await expect(
+      service.shouldNotify('u1', NotificationChannel.PUSH, NotificationEventType.KYC),
+    ).resolves.toBe(false);
+  });
+
+  it('creates a preference when none exists for the pair', async () => {
+    const created = { isEnabled: true, batchingEnabled: true };
+    const repo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      create: jest.fn((dto) => ({ ...dto })),
+      save: jest.fn((dto) => Promise.resolve({ ...created, ...dto })),
+    };
+    const service = new NotificationPreferencesService(repo as any);
+    const result = await service.updatePreference('u1', {
+      channel: NotificationChannel.EMAIL,
+      eventType: NotificationEventType.TRANSACTION,
+      isEnabled: true,
+    });
+    expect(result.isEnabled).toBe(true);
+    expect(result.batchingEnabled).toBe(true);
+  });
+});
+
+describe('ScheduledReportsService', () => {
+  it('schedules the first run from the requested frequency', async () => {
+    const repo = {
+      create: jest.fn((row) => ({ ...row })),
+      save: jest.fn((row) => Promise.resolve(row)),
+      find: jest.fn(),
+      findOne: jest.fn(),
+    };
+    const service = new ScheduledReportsService(repo as any);
+    const created = await service.create({
+      userId: 'u1',
+      reportType: ReportType.FEE_SUMMARY,
+      frequency: ReportFrequency.DAILY,
+    });
+    expect(created.nextRunAt.getTime()).toBeGreaterThan(Date.now());
+    expect(created.userId).toBe('u1');
+  });
+
+  it('throws when deactivating an unknown report', async () => {
+    const repo = { findOne: jest.fn().mockResolvedValue(null) };
+    const service = new ScheduledReportsService(repo as any);
+    await expect(service.deactivate('missing-id')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});
+
+describe('TermsController', () => {
+  it('records acceptance for the authenticated user', async () => {
+    const termsService = {
+      accept: jest.fn().mockResolvedValue({ userId: 'u1', version: '1.0' }),
+    };
+    const controller = new TermsController(termsService as any);
+    const result = await controller.accept({
+      user: { sub: 'u1' },
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'jest' },
+    } as any);
+    expect(termsService.accept).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u1' }),
+    );
+    expect(result.userId).toBe('u1');
+  });
+
+  it('rejects requests without an authenticated user', async () => {
+    const controller = new TermsController({ accept: jest.fn() } as any);
+    await expect(controller.accept({} as any)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/src/stellar/ibinola-features.spec.ts
+++ b/src/stellar/ibinola-features.spec.ts
@@ -1,6 +1,6 @@
-import { StellarService } from './stellar/stellar.service';
-import { AmlService } from './aml/aml.service';
-import { PaymentProviderService } from './payments/payment-provider.service';
+import { StellarService } from './stellar.service';
+import { AmlService } from '../aml/aml.service';
+import { PaymentProviderService } from '../payments/payment-provider.service';
 
 describe('ibinola Features (Issues #996, #995, #994, #993)', () => {
   it('StellarService supports NFT receipt minting', async () => {

--- a/src/transactions/danielships-features.spec.ts
+++ b/src/transactions/danielships-features.spec.ts
@@ -1,6 +1,6 @@
-import { ExchangeRatesService } from './exchange-rates/exchange-rates.service';
-import { PaymentProviderService } from './payments/payment-provider.service';
-import { TransactionsService } from './transactions/transactions.service';
+import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
+import { PaymentProviderService } from '../payments/payment-provider.service';
+import { TransactionsService } from './transactions.service';
 
 describe('danielships Features (Issues #984, #983, #982, #981)', () => {
   it('ExchangeRatesService provides public exchange rates dataset', async () => {

--- a/src/transactions/femaleotaku-features.spec.ts
+++ b/src/transactions/femaleotaku-features.spec.ts
@@ -1,6 +1,6 @@
-import { TransactionsService } from './transactions/transactions.service';
-import { FxService } from './fx/fx.service';
-import { AdminService } from './admin/admin.service';
+import { TransactionsService } from './transactions.service';
+import { FxService } from '../fx/fx.service';
+import { AdminService } from '../admin/admin.service';
 
 describe('femaleotaku Features (Issues #988, #987, #986, #985)', () => {
   it('TransactionsService supports user-to-user internal transfer', async () => {

--- a/src/wallet/prismn-features.spec.ts
+++ b/src/wallet/prismn-features.spec.ts
@@ -1,7 +1,7 @@
-import { WalletsService } from './wallet/wallets.service';
-import { StellarService } from './stellar/stellar.service';
-import { TransactionsService } from './transactions/transactions.service';
-import { NotificationPreferencesService } from './notification-preferences/notification-preferences.service';
+import { WalletsService } from './wallets.service';
+import { StellarService } from '../stellar/stellar.service';
+import { TransactionsService } from '../transactions/transactions.service';
+import { NotificationPreferencesService } from '../notification-preferences/notification-preferences.service';
 
 describe('prismn Features (Issues #976, #934, #921, #920)', () => {
   it('WalletsService supports configurable auto-sweep for wallet balance management', async () => {


### PR DESCRIPTION
Addresses the four issues assigned to this account.

- #1137: FeeRevenueController was an orphaned stub with no module. Added src/reports/fee-revenue.module.ts and registered it in AppModule so the controller is reachable.
- #1138: S3Service in src/documents was never provided. DocumentsModule now registers it as a provider so it can be injected for KYC upload/download URLs.
- #1139: the seven top-level contributor-named *-features.spec.ts files now live inside the modules they primarily cover (admin, transactions, stellar, kyc, wallet), with imports fixed.
- #1140: added unit tests for NotificationPreferencesService, ScheduledReportsService, and TermsController, which previously had zero coverage.

Closes #1137
Closes #1138
Closes #1139
Closes #1140