### PR TITLE
fix(notifications,referral): dispatch push notifications, expose referral lifecycle endpoints, scope wallet credit and stats

### DIFF
--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bull';
 import { QUEUE_NAMES } from '../queues/queue.constants';
 import { NotificationProcessor } from './notification.processor';
+import { PushModule } from '../notifications/push/push.module';
 
 @Module({
   imports: [
+    PushModule,
     BullModule.registerQueue({
       name: QUEUE_NAMES.NOTIFICATION,
       defaultJobOptions: {

--- a/src/notification/notification.processor.ts
+++ b/src/notification/notification.processor.ts
@@ -2,6 +2,7 @@ import { Processor, Process, OnQueueFailed, OnQueueError } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job } from 'bull';
 import { NOTIFICATION_JOB_NAMES, QUEUE_NAMES } from '../queues/queue.constants';
+import { PushNotificationService } from '../notifications/push/push.service';
 
 export interface NotificationJobData {
   userId: string;
@@ -14,13 +15,15 @@ export interface NotificationJobData {
 export class NotificationProcessor {
   private readonly logger = new Logger(NotificationProcessor.name);
 
+  constructor(private readonly pushService: PushNotificationService) {}
+
   @Process(NOTIFICATION_JOB_NAMES.DISPATCH)
-  handleDispatch(job: Job<NotificationJobData>): void {
+  async handleDispatch(job: Job<NotificationJobData>): Promise<void> {
     this.logger.log(
       `Processing job ${job.id} (${job.name}) — dispatching notification to user ${job.data.userId}`,
     );
 
-    const { userId, title, body } = job.data;
+    const { userId, title, body, data } = job.data;
 
     if (!userId || !title || !body) {
       throw new Error(
@@ -28,8 +31,7 @@ export class NotificationProcessor {
       );
     }
 
-    // Push notification transport integration point (FCM/APNs).
-    this.logger.log(`Notification dispatched to user ${userId}: "${title}"`);
+    await this.pushService.sendToUser(userId, { title, body, data });
   }
 
   @OnQueueFailed()

--- a/src/referral/referral.controller.ts
+++ b/src/referral/referral.controller.ts
@@ -39,4 +39,24 @@ export class ReferralController {
     const userId = req.user?.sub ?? '';
     return this.referralService.findByReferrer(userId);
   }
+
+  @Post('apply')
+  @HttpCode(HttpStatus.CREATED)
+  applyCode(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { code?: string },
+  ) {
+    const userId = req.user?.sub ?? '';
+    return this.referralService.applyCode(body.code ?? '', userId);
+  }
+
+  @Post(':id/qualify')
+  qualify(@Param('id') id: string) {
+    return this.referralService.qualifyReferral(id);
+  }
+
+  @Post(':id/reward')
+  reward(@Param('id') id: string) {
+    return this.referralService.rewardReferral(id);
+  }
 }

--- a/src/referral/referral.service.ts
+++ b/src/referral/referral.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import { Referral, ReferralStatus } from './referral.entity';
 import { ReferralReward, RewardType, RewardStatus } from './referral-reward.entity';
@@ -92,9 +92,15 @@ export class ReferralService {
     const qualified = all.filter((r) => r.status === ReferralStatus.QUALIFIED).length;
     const rewarded = all.filter((r) => r.status === ReferralStatus.REWARDED).length;
 
-    const rewards = await this.rewardRepo.find({
-      where: all.filter((r) => r.status === ReferralStatus.REWARDED).map((r) => ({ referralId: r.id })),
-    });
+    const rewardedIds = all
+      .filter((r) => r.status === ReferralStatus.REWARDED)
+      .map((r) => r.id);
+
+    const rewards = rewardedIds.length
+      ? await this.rewardRepo.find({
+          where: { referralId: In(rewardedIds) },
+        })
+      : [];
 
     const totalRewardsPaid = rewards
       .filter((r) => r.status === RewardStatus.PAID)
@@ -146,7 +152,12 @@ export class ReferralService {
     const rewardAmount = this.config.get<number>('referral.rewardAmount') ?? 10;
 
     return this.dataSource.transaction(async (manager) => {
-      await this.wallets.adjustBalance(referral.referrerId, 'USD', rewardAmount);
+      await this.wallets.adjustBalance(
+        referral.referrerId,
+        'USD',
+        rewardAmount,
+        manager,
+      );
 
       const reward = manager.create(ReferralReward, {
         referralId: referral.id,


### PR DESCRIPTION
Addresses the four issues assigned to this account.

- #1129: NotificationProcessor.handleDispatch is no longer a no-op. It now dispatches through PushNotificationService (with NotificationQueueModule importing PushModule), so queue jobs reach registered devices.
- #1130: the referral reward flow is now reachable — added POST apply, POST :id/qualify, and POST :id/reward endpoints alongside the existing generate/stats routes.
- #1131: rewardReferral now passes the active transaction manager to wallets.adjustBalance so the wallet credit, reward record, and referral status commit (or roll back) atomically.
- #1132: getStats scopes the reward query to the caller's own rewarded referral IDs; the previous empty-array where clause matched all reward rows. Empty result sets now yield zero totals instead of leaking other users' rewards.

Closes #1129
Closes #1130
Closes #1131
Closes #1132