### PR TITLE
feat(scheduled-reports): add execution engine that consumes nextRunAt

### DIFF
--- a/src/scheduled-reports/scheduled-reports.service.ts
+++ b/src/scheduled-reports/scheduled-reports.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { LessThanOrEqual, Repository } from 'typeorm';
 import {
   ScheduledReport,
   ReportType,
@@ -42,6 +43,22 @@ export class ScheduledReportsService {
     }
     report.isActive = false;
     return this.reportRepo.save(report);
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async processDueReports(): Promise<void> {
+    const now = new Date();
+    const due = await this.reportRepo.find({
+      where: { isActive: true, nextRunAt: LessThanOrEqual(now) },
+      order: { nextRunAt: 'ASC' },
+    });
+
+    for (const report of due) {
+      await this.generateReport(report.reportType);
+      report.lastRunAt = new Date();
+      report.nextRunAt = this.computeNextRun(report.frequency);
+      await this.reportRepo.save(report);
+    }
   }
 
   async generateReport(_reportType: ReportType): Promise<Record<string, unknown>> {


### PR DESCRIPTION
Addresses the four issues assigned to this account.

### #1141 — scheduled reports execution engine
Added a minute-level cron job to ScheduledReportsService that queries for active reports whose nextRunAt has passed, calls generateReport, and advances the schedule. nextRunAt is no longer computed-but-unconsumed.

### #1142 — configuration.ts missing closing brace (already fixed)
Verified on main: brace balance is 0 across the entire file — no unmatched braces. No code change required.

### #1143 — transactions.controller.ts duplicate class (already fixed)
Verified on main: the live file at src/transactions/transactions.controller.ts contains exactly one export class TransactionsController. No code change required.

### #1144 — wallets.service.ts stray extra closing brace (already fixed)
Verified on main: brace balance is 0 across the entire file — no unmatched braces. No code change required.

Closes #1141
Closes #1142
Closes #1143
Closes #1144